### PR TITLE
Add contraints for the template parameters

### DIFF
--- a/src/Agent.hpp
+++ b/src/Agent.hpp
@@ -4,10 +4,12 @@
 
 #include "Itinerary.hpp"
 #include "SparseMatrix.hpp"
+#include "utility/TypeTraits.hpp"
 
 namespace dmf {
 
   template <typename Id, typename Weight>
+    requires (std::unsigned_integral<Id> && is_numeric_v<Weight>)
   class Agent {
   private:
     Id m_index;
@@ -36,10 +38,12 @@ namespace dmf {
   };
 
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   Agent<Id, Weight>::Agent(Id index, Id position)
       : m_index{index}, m_position{position}, m_previousPosition{position} {}
 
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   Agent<Id, Weight>::Agent(Id index, Id position, Itinerary<Id> itinerary)
       : m_index{index},
         m_position{position},
@@ -47,6 +51,7 @@ namespace dmf {
         m_itinerary{std::move(itinerary)} {}
 
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   Agent<Id, Weight>::Agent(Id index, Id position, Itinerary<Id> itinerary, SparseMatrix<Id, Weight> matrix)
       : m_index{index},
         m_position{position},
@@ -56,36 +61,44 @@ namespace dmf {
 
   // Setters
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   void Agent<Id, Weight>::setPosition(Id position) {
     m_position = position;
   }
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   void Agent<Id, Weight>::setItinerary(Itinerary<Id> itinerary) {
     m_itinerary = std::move(itinerary);
   }
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   void Agent<Id, Weight>::setTransitionMatrix(SparseMatrix<Id, Weight> matrix) {
     m_transitionMatrix = std::move(matrix);
   }
 
   // Getters
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   int Agent<Id, Weight>::index() const {
     return m_index;
   }
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   int Agent<Id, Weight>::position() const {
     return m_position;
   }
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   int Agent<Id, Weight>::previousPosition() const {
     return m_previousPosition;
   }
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   const Itinerary<Id>& Agent<Id, Weight>::itinerary() const {
     return m_itinerary;
   }
   template <typename Id, typename Weight>
+    requires std::unsigned_integral<Id>
   const SparseMatrix<Id, Weight>& Agent<Id, Weight>::transitionMatrix() const {
     return m_transitionMatrix;
   }

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -2,6 +2,7 @@
 #ifndef Graph_hpp
 #define Graph_hpp
 
+#include <concepts>
 #include <memory>
 #include <unordered_set>
 #include <queue>
@@ -21,6 +22,7 @@ namespace dmf {
   using std::make_shared;
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Graph {
   private:
     shared<SparseMatrix<Id, bool>> m_adjacency;
@@ -57,6 +59,7 @@ namespace dmf {
   };
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Graph<Id, Size>::Graph(const std::unordered_set<shared<Street<Id, Size>>, nodeHash<Id>>& streetSet)
       : m_adjacency{make_shared<SparseMatrix<Id, Size>>()} {
     for (auto street : streetSet) {
@@ -69,6 +72,7 @@ namespace dmf {
   }
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::buildAdj() {
     for (auto street : m_streets) {
       m_adjacency->insert(street->nodes().first, street->nodes().second, true);
@@ -76,21 +80,25 @@ namespace dmf {
   }
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addNode(shared<Node<Id>> node) {
     m_nodes.insert(node);
   }
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addNode(const Node<Id>& node) {
     m_nodes.insert(make_shared<Node<Id>>(node));
   }
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   template <typename... Tn>
     requires(is_node_v<Tn> && ...)
   void Graph<Id, Size>::addNodes(Tn... nodes) {}
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   template <typename T1, typename... Tn>
     requires is_node_v<T1> && (is_node_v<Tn> && ...)
   void Graph<Id, Size>::addNodes(T1 node, Tn... nodes) {
@@ -99,21 +107,25 @@ namespace dmf {
   }
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addStreet(shared<Street<Id, Size>> street) {
     m_streets.insert(street);
   }
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addStreet(const Street<Id, Size>& street) {
     m_streets.insert(make_shared<Street<Id, Size>>(street));
   }
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   template <typename... Tn>
     requires(is_street_v<Tn> && ...)
   void Graph<Id, Size>::addStreets(Tn... edges) {}
 
   template <typename Id, typename Size>
+	requires (std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   template <typename T1, typename... Tn>
     requires is_street_v<T1> && (is_street_v<Tn> && ...)
   void Graph<Id, Size>::addStreets(T1 street, Tn... streets) {

--- a/src/Itinerary.hpp
+++ b/src/Itinerary.hpp
@@ -2,11 +2,13 @@
 #ifndef Itinerary_hpp
 #define Itinerary_hpp
 
+#include <concepts>
 #include <utility>
 
 namespace dmf {
 
   template <typename Id>
+	requires std::unsigned_integral<Id>
   class Itinerary {
   private:
     std::pair<Id, Id> m_trip;

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -9,6 +9,7 @@
 namespace dmf {
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   class Node {
   private:
     Id m_id;
@@ -21,47 +22,55 @@ namespace dmf {
     Node(Id id, std::pair<double, double> coords);
     Node(Id id, std::pair<double, double> coords, std::queue<Id> queue);
 
-	// Setters
-	void setCoords(std::pair<double, double> coords);
-	void setQueue(std::queue<Id> queue);
+    // Setters
+    void setCoords(std::pair<double, double> coords);
+    void setQueue(std::queue<Id> queue);
 
-	// Getters
+    // Getters
     Id id() const;
     const std::pair<double, double>& coords() const;
     const std::queue<Id>& queue() const;
   };
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   Node<Id>::Node(Id id) : m_id{id} {}
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   Node<Id>::Node(Id id, std::pair<double, double> coords) : m_id{id}, m_coords{std::move(coords)} {}
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   Node<Id>::Node(Id id, std::pair<double, double> coords, std::queue<Id> queue)
       : m_id{id}, m_coords{std::move(coords)}, m_queue{std::move(queue)} {}
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   Id Node<Id>::id() const {
     return m_id;
   }
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   void Node<Id>::setCoords(std::pair<double, double> coords) {
-	m_coords = std::move(coords);
+    m_coords = std::move(coords);
   }
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   void Node<Id>::setQueue(std::queue<Id> queue) {
-	m_queue = std::move(queue);
+    m_queue = std::move(queue);
   }
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   const std::pair<double, double>& Node<Id>::coords() const {
     return m_coords;
   }
 
   template <typename Id>
+    requires std::unsigned_integral<Id>
   const std::queue<Id>& Node<Id>::queue() const {
     return m_queue;
   }

--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -6,6 +6,7 @@
 #ifndef SparseMatrix_hpp
 #define SparseMatrix_hpp
 
+#include <concepts>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
@@ -17,6 +18,7 @@
 namespace dmf {
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   class SparseMatrix {
     std::unordered_map<Index, T> _matrix;
     Index _rows, _cols;
@@ -190,6 +192,7 @@ namespace dmf {
     /// @return the sum of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
     template <typename I, typename U>
+      requires std::unsigned_integral<I>
     SparseMatrix<Index, T> operator+(const SparseMatrix<I, U>& other) {
       if (this->_rows != other._rows || this->_cols != other._cols) {
         throw std::runtime_error("SparseMatrix: dimensions do not match");
@@ -213,6 +216,7 @@ namespace dmf {
     /// @return the difference of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
     template <typename I, typename U>
+      requires std::unsigned_integral<I>
     SparseMatrix<Index, T> operator-(const SparseMatrix<I, U>& other) {
       if (this->_rows != other._rows || this->_cols != other._cols) {
         throw std::runtime_error("SparseMatrix: dimensions do not match");
@@ -240,6 +244,7 @@ namespace dmf {
     /// @return the sum of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
     template <typename I, typename U>
+      requires std::unsigned_integral<I>
     SparseMatrix& operator+=(const SparseMatrix<I, U>& other);
 
     /// @brief difference of two matrices
@@ -247,62 +252,65 @@ namespace dmf {
     /// @return the difference of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
     template <typename I, typename U>
+      requires std::unsigned_integral<I>
     SparseMatrix& operator-=(const SparseMatrix<I, U>& other);
   };
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, T>::SparseMatrix()
       : _matrix{std::unordered_map<Index, T>()}, _rows{}, _cols{}, _defaultReturn{0} {}
 
   template <typename Index, typename T>
-  SparseMatrix<Index, T>::SparseMatrix(Index rows, Index cols) : _matrix{std::unordered_map<Index, T>()} {
-    rows < 0 || cols < 0 ? throw std::invalid_argument("SparseMatrix: rows and cols must be > 0")
-                         : _rows = rows,
-                           _cols = cols;
-    _defaultReturn = 0;
-  }
+    requires std::unsigned_integral<Index>
+  SparseMatrix<Index, T>::SparseMatrix(Index rows, Index cols)
+      : _matrix{std::unordered_map<Index, T>()}, _rows{rows}, _cols{cols}, _defaultReturn{0} {}
 
   template <typename Index, typename T>
-  SparseMatrix<Index, T>::SparseMatrix(Index index) : _matrix{std::unordered_map<Index, T>()} {
-    index < 0 ? throw std::invalid_argument("SparseMatrix: index must be > 0") : _rows = index, _cols = 1;
-    _defaultReturn = 0;
-  }
+    requires std::unsigned_integral<Index>
+  SparseMatrix<Index, T>::SparseMatrix(Index index)
+      : _matrix{std::unordered_map<Index, T>()}, _rows{index}, _cols{1}, _defaultReturn{0} {}
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::insert(Index i, Index j, T value) {
-    if (i >= _rows || j >= _cols || i < 0 || j < 0) {
+    if (i >= _rows || j >= _cols) {
       throw std::out_of_range("Index out of range");
     }
     _matrix.emplace(std::make_pair(i * _cols + j, value));
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::insert(Index i, T value) {
-    if (i >= _rows * _cols || i < 0) {
+    if (i >= _rows * _cols) {
       throw std::out_of_range("Index out of range");
     }
     _matrix.emplace(std::make_pair(i, value));
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::insert_or_assign(Index i, Index j, T value) {
-    if (i >= _rows || j >= _cols || i < 0 || j < 0) {
+    if (i >= _rows || j >= _cols) {
       throw std::out_of_range("Index out of range");
     }
     _matrix.insert_or_assign(i * _cols + j, value);
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::insert_or_assign(Index index, T value) {
-    if (index < 0 || index > _rows * _cols - 1) {
+    if (index > _rows * _cols - 1) {
       throw std::out_of_range("Index out of range");
     }
     _matrix.insert_or_assign(index, value);
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::erase(Index i, Index j) {
-    if (i >= _rows || j >= _cols || i < 0 || j < 0) {
+    if (i >= _rows || j >= _cols) {
       throw std::out_of_range("Index out of range");
     }
     _matrix.find(i * _cols + j) != _matrix.end()
@@ -311,8 +319,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::eraseRow(Index index) {
-    if (index < 0 || index > _rows - 1) {
+    if (index > _rows - 1) {
       throw std::out_of_range("Index out of range");
     }
     for (Index i = 0; i < _cols; ++i) {
@@ -331,8 +340,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::eraseColumn(Index index) {
-    if (index < 0 || index > _cols - 1) {
+    if (index > _cols - 1) {
       throw std::out_of_range("Index out of range");
     }
     for (Index i = 0; i < _rows; ++i) {
@@ -351,6 +361,7 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::clear() {
     _matrix.clear();
     _rows = 0;
@@ -358,22 +369,25 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   bool SparseMatrix<Index, T>::contains(Index i, Index j) const {
-    if (i >= _rows || j >= _cols || i < 0 || j < 0) {
+    if (i >= _rows || j >= _cols) {
       throw std::out_of_range("Index out of range");
     }
     return _matrix.contains(i * _cols + j);
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   bool SparseMatrix<Index, T>::contains(Index const index) const {
-    if (index < 0 || index > _rows * _cols - 1) {
+    if (index > _rows * _cols - 1) {
       throw std::out_of_range("Index out of range");
     }
     return _matrix.contains(index);
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, int> SparseMatrix<Index, T>::getDegreeVector() {
     if (_rows != _cols) {
       throw std::runtime_error("SparseMatrix: getDegreeVector only works on square matrices");
@@ -386,6 +400,7 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, double> SparseMatrix<Index, T>::getStrengthVector() {
     if (_rows != _cols) {
       throw std::runtime_error("SparseMatrix: getStrengthVector only works on square matrices");
@@ -398,6 +413,7 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, int> SparseMatrix<Index, T>::getLaplacian() {
     if (_rows != _cols) {
       throw std::runtime_error("SparseMatrix: getLaplacian only works on square matrices");
@@ -414,8 +430,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, T> SparseMatrix<Index, T>::getRow(Index index) const {
-    if (index >= _rows || index < 0) {
+    if (index >= _rows) {
       throw std::out_of_range("Index out of range");
     }
     SparseMatrix row(1, _cols);
@@ -428,8 +445,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, T> SparseMatrix<Index, T>::getCol(Index index) const {
-    if (index >= _cols || index < 0) {
+    if (index >= _cols) {
       throw std::out_of_range("Index out of range");
     }
     SparseMatrix col(_rows, 1);
@@ -442,6 +460,7 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, double> SparseMatrix<Index, T>::getNormRows() const {
     SparseMatrix<Index, double> normRows(_rows, _cols);
     for (Index index = 0; index < _rows; ++index) {
@@ -459,6 +478,7 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, double> SparseMatrix<Index, T>::getNormCols() const {
     SparseMatrix<Index, double> normCols(_rows, _cols);
     for (Index index = 0; index < _cols; ++index) {
@@ -476,43 +496,51 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   Index SparseMatrix<Index, T>::getRowDim() const {
     return this->_rows;
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   Index SparseMatrix<Index, T>::getColDim() const {
     return this->_cols;
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   Index SparseMatrix<Index, T>::size() const {
     return _matrix.size();
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   Index SparseMatrix<Index, T>::max_size() const {
     return this->_rows * this->_cols;
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   void SparseMatrix<Index, T>::symmetrize() {
     *this += this->operator++();
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   typename std::unordered_map<Index, T>::const_iterator SparseMatrix<Index, T>::begin() const {
     return _matrix.begin();
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   typename std::unordered_map<Index, T>::const_iterator SparseMatrix<Index, T>::end() const {
     return _matrix.end();
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   const T& SparseMatrix<Index, T>::operator()(Index i, Index j) const {
-    if (i >= _rows || j >= _cols || i < 0 || j < 0) {
+    if (i >= _rows || j >= _cols) {
       throw std::out_of_range("Index out of range");
     }
     auto const& it = _matrix.find(i * _cols + j);
@@ -520,8 +548,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   T& SparseMatrix<Index, T>::operator()(Index i, Index j) {
-    if (i >= _rows || j >= _cols || i < 0 || j < 0) {
+    if (i >= _rows || j >= _cols) {
       throw std::out_of_range("Index out of range");
     }
     auto const& it = _matrix.find(i * _cols + j);
@@ -529,8 +558,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   const T& SparseMatrix<Index, T>::operator()(Index index) const {
-    if (index >= _rows * _cols || index < 0) {
+    if (index >= _rows * _cols) {
       throw std::out_of_range("Index out of range");
     }
     auto const& it = _matrix.find(index);
@@ -538,8 +568,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   T& SparseMatrix<Index, T>::operator()(Index index) {
-    if (index >= _rows * _cols || index < 0) {
+    if (index >= _rows * _cols) {
       throw std::out_of_range("Index out of range");
     }
     auto const& it = _matrix.find(index);
@@ -547,6 +578,7 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   SparseMatrix<Index, T> SparseMatrix<Index, T>::operator++() {
     auto transpost = SparseMatrix(this->_cols, this->_rows);
     for (auto& it : _matrix) {
@@ -556,7 +588,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   template <typename I, typename U>
+    requires std::unsigned_integral<I>
   SparseMatrix<Index, T>& SparseMatrix<Index, T>::operator+=(const SparseMatrix<I, U>& other) {
     if (this->_rows != other._rows || this->_cols != other._cols) {
       throw std::runtime_error("SparseMatrix: dimensions do not match");
@@ -569,7 +603,9 @@ namespace dmf {
   }
 
   template <typename Index, typename T>
+    requires std::unsigned_integral<Index>
   template <typename I, typename U>
+    requires std::unsigned_integral<I>
   SparseMatrix<Index, T>& SparseMatrix<Index, T>::operator-=(const SparseMatrix<I, U>& other) {
     if (this->_rows != other._rows || this->_cols != other._cols) {
       throw std::runtime_error("SparseMatrix: dimensions do not match");

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -8,6 +8,7 @@
 namespace dmf {
 
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Street {
   private:
     Id m_id;
@@ -24,53 +25,62 @@ namespace dmf {
 
     // Setters
     void setCapacity(Size capacity);
-	void setLength(double len);
+    void setLength(double len);
     void setQueue(std::queue<Size> queue);
 
     // Getters
     Id id() const;
     Size size() const;
     Size capacity() const;
-	double length() const;
+    double length() const;
     const std::queue<Size>& queue() const;
     const std::pair<Id, Id>& nodePair() const;
   };
 
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Street<Id, Size>::Street(Id index, Size capacity, double len) : m_capacity{capacity}, m_len{len} {}
 
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Street<Id, Size>::Street(Id index, Size size, Size capacity, double len)
       : m_size{size}, m_capacity{capacity}, m_len{len} {}
 
   // Setters
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Street<Id, Size>::setCapacity(Size capacity) {
     m_capacity = capacity;
   }
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Street<Id, Size>::setLength(double len) {
-	m_len = len;
+    m_len = len;
   }
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Street<Id, Size>::setQueue(std::queue<Size> queue) {
     m_queue = std::move(queue);
   }
 
   // Getters
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Size Street<Id, Size>::size() const {
     return m_size;
   }
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Size Street<Id, Size>::capacity() const {
     return m_capacity;
   }
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   double Street<Id, Size>::length() const {
     return m_len;
   }
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   const std::queue<Size>& Street<Id, Size>::queue() const {
     return m_queue;
   }

--- a/src/utility/TypeTraits.hpp
+++ b/src/utility/TypeTraits.hpp
@@ -1,11 +1,17 @@
 #ifndef TypeTraits_hpp
 #define TypeTraits_hpp
 
+#include <concepts>
+#include <memory>
 #include <type_traits>
 
+#include "../Node.hpp"
 #include "../Street.hpp"
 
 namespace dmf {
+  // Alias for shared pointers
+  template <typename T>
+  using shared = std::shared_ptr<T>;
 
   template <typename T>
   struct is_node : std::false_type {};

--- a/src/utility/TypeTraits.hpp
+++ b/src/utility/TypeTraits.hpp
@@ -37,6 +37,12 @@ namespace dmf {
   template <typename T>
   inline constexpr bool is_street_v = is_street<T>::value;
 
+  // define is_numeric_v type trait
+  template <typename T>
+  inline constexpr bool is_numeric_v =
+      (std::is_integral_v<T> || std::is_floating_point_v<T>)&&!std::is_same_v<T, bool> &&
+      !std::is_same_v<T, char>;
+
 };  // namespace dmf
 
 #endif

--- a/test/Test_sparsematrix.cpp
+++ b/test/Test_sparsematrix.cpp
@@ -15,22 +15,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the matrix is created
     THEN: the matrix should have 0 rows and 0 columns and a max size of 0
     */
-    SparseMatrix<int, bool> m;
+    SparseMatrix<uint32_t, bool> m;
     // Check the dimensions
     CHECK(m.getRowDim() == 0);
     CHECK(m.getColDim() == 0);
     CHECK(m.max_size() == 0);
-  }
-  SUBCASE("Constructor - exceptions") {
-    /*This test tests if the constructor throws exceptions correctly
-    The constructor should throw an exception if the dimensions are negative
-    GIVEN: the constructor is called with negative dimensions
-    WHEN: the matrix is created
-    THEN: the matrix should throw an exception
-    */
-    CHECK_THROWS(SparseMatrix<int, bool>(-2, 0));
-    CHECK_THROWS(SparseMatrix<int, bool>(0, -10));
-    CHECK_THROWS(SparseMatrix<int, bool>(-4));
   }
   SUBCASE("Constructor with dimensions") {
     /*This test tests if the constructor with dimensions works correctly
@@ -40,14 +29,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the matrix is created
     THEN: the matrix should have 3 rows and 4 columns and a max size of 12
     */
-    SparseMatrix<int, bool> m(3, 4);
+    SparseMatrix<uint32_t, bool> m(3, 4);
     // Check the dimensions
     CHECK(m.getRowDim() == 3);
     CHECK(m.getColDim() == 4);
     CHECK(m.max_size() == 12);
-    // Check out of range exceptions
-    CHECK_THROWS(m(-1, 0));
-    CHECK_THROWS(m(0, -1));
   }
   SUBCASE("Constructor with dimension") {
     /*This test tests if the constructor with dimension works correctly
@@ -56,27 +42,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the matrix is created
     THEN: the matrix should have 3 rows and 1 column and a max size of 3
     */
-    SparseMatrix<int, bool> m(3);
+    SparseMatrix<uint32_t, bool> m(3);
     // Check the dimensions
     CHECK(m.getRowDim() == 3);
     CHECK(m.getColDim() == 1);
     CHECK(m.max_size() == 3);
-    // Check out of range exceptions
-    CHECK_THROWS(m(-1));
-  }
-  SUBCASE("Insertion exceptions") {
-    /*This test tests if the insert function throws exceptions correctly
-    The insert function should throw an exception if the inserted element is out
-    of range
-    GIVEN: the insert function is called
-    WHEN: the function is called on a matrix
-    THEN: the function should throw an exception if the inserted element is out
-    of range
-    */
-    SparseMatrix<int, bool> m(3, 3);
-    // Check that an exception is thrown if the element is out of range
-    CHECK_THROWS(m.insert(-1, true));
-    CHECK_THROWS(m.insert(3, 2, true));
   }
   SUBCASE("insert_or_assign exceptions") {
     /*This test tests if the insert_or_assign function throws exceptions
@@ -87,9 +57,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the inserted element is out
     of range
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     // Check that an exception is thrown if the element is out of range
-    CHECK_THROWS(m.insert_or_assign(-1, -2, true));
     CHECK_THROWS(m.insert_or_assign(3, 2, true));
   }
   SUBCASE("Insertions") {
@@ -99,14 +68,14 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should insert a value in the matrix
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     // Insert a true value
     m.insert(0, 0, true);
     m.insert(5, true);
     // Check all values
     CHECK(m(0, 0));
     CHECK(m(1, 2));
-    for (int i = 1; i < 9; ++i) {
+    for (uint32_t i = 1; i < 9; ++i) {
       if (i != 5) {
         CHECK(!m(i / 3, i % 3));
       }
@@ -120,7 +89,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should insert a value in the matrix
     */
-    SparseMatrix<int, int> m(4, 3);
+    SparseMatrix<uint32_t, int> m(4, 3);
     // Insert a true value
     m.insert_or_assign(1, 2, 10);
     CHECK(m(1, 2) == 10);
@@ -134,7 +103,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the element is out of range
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     // Check that an exception is thrown if the element is out of range
     CHECK_THROWS(m.erase(-1, -2));
     CHECK_THROWS(m.erase(3, 2));
@@ -146,7 +115,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should delete a value in the matrix
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.erase(0, 0);
     // Check if the value has been deleted
@@ -161,7 +130,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should delete all the elements and dimensions in the
     matrix
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.clear();
     // Check if the matrix is empty
@@ -176,7 +145,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the element is out of range
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     CHECK_THROWS(m.contains(-2, -1));
     CHECK_THROWS(m.contains(-1));
   }
@@ -187,7 +156,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called
     THEN: the function should return true
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(2, 1, true);
     CHECK(m.contains(0, 0));
@@ -200,7 +169,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the row is out of range
     */
-    SparseMatrix<int, bool> m(4, 3);
+    SparseMatrix<uint32_t, bool> m(4, 3);
     CHECK_THROWS(m.getRow(-1));
     CHECK_THROWS(m.getRow(4));
   }
@@ -213,7 +182,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return a vector (SparseMatrix) containing the
     elements of the row
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     // Create a row
     m.insert(0, 0, true);
     m.insert(0, 2, true);
@@ -232,8 +201,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the column is out of range
     */
-    SparseMatrix<int, bool> m(3, 6);
-    CHECK_THROWS(m.getCol(-1));
+    SparseMatrix<uint32_t, bool> m(3, 6);
     CHECK_THROWS(m.getCol(6));
   }
   SUBCASE("Get column") {
@@ -245,7 +213,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return a vector (SparseMatrix) containingthe
     elements of the column
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     // Create a column
     m.insert(0, 0, true);
     m.insert(2, 0, true);
@@ -263,7 +231,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the number of rows in the matrix
     */
-    SparseMatrix<int, bool> m(7, 3);
+    SparseMatrix<uint32_t, bool> m(7, 3);
     CHECK(m.getRowDim() == 7);
   }
   SUBCASE("Get column dimension") {
@@ -273,7 +241,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the number of columns in the matrix
     */
-    SparseMatrix<int, bool> m(3, 10);
+    SparseMatrix<uint32_t, bool> m(3, 10);
     CHECK(m.getColDim() == 10);
   }
   SUBCASE("Get max_size") {
@@ -285,7 +253,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return the maximum number of elements that can be
     stored in the matrix
     */
-    SparseMatrix<int, bool> m(3, 5);
+    SparseMatrix<uint32_t, bool> m(3, 5);
     CHECK(m.max_size() == 15);
   }
   SUBCASE("Get size") {
@@ -296,7 +264,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the number of elements in the matrix
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(0, 2, true);
@@ -311,8 +279,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the row is out of range
     */
-    SparseMatrix<int, bool> m(5, 3);
-    CHECK_THROWS(m.eraseRow(-1));
+    SparseMatrix<uint32_t, bool> m(5, 3);
     CHECK_THROWS(m.eraseRow(5));
   }
   SUBCASE("Erase row") {
@@ -323,7 +290,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should delete all the elements in the row
     */
-    SparseMatrix<int, bool> d(3, 3);
+    SparseMatrix<uint32_t, bool> d(3, 3);
     // Create a row
     d.insert(0, 0, true);
     d.insert(1, 2, true);
@@ -355,8 +322,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the column is out of range
     */
-    SparseMatrix<int, bool> m(3, 5);
-    CHECK_THROWS(m.eraseColumn(-1));
+    SparseMatrix<uint32_t, bool> m(3, 5);
     CHECK_THROWS(m.eraseColumn(5));
   }
   SUBCASE("Erase column") {
@@ -367,7 +333,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should delete all the elements in the column
     */
-    SparseMatrix<int, bool> d(3, 3);
+    SparseMatrix<uint32_t, bool> d(3, 3);
     d.insert(0, 0, true);
     d.insert(1, 2, true);
     d.insert(2, 1, true);
@@ -394,8 +360,8 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the matrix is empty
     */
-    SparseMatrix<int, bool> m(1, 5);
-    SparseMatrix<int, bool> m2(3, 6);
+    SparseMatrix<uint32_t, bool> m(1, 5);
+    SparseMatrix<uint32_t, bool> m2(3, 6);
     CHECK_THROWS(m.getDegreeVector());
     CHECK_THROWS(m2.getDegreeVector());
   }
@@ -407,7 +373,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return a vector containing the degree of each row
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -428,7 +394,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return a matrix containing the normalized rows
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     // Create a row
     m.insert(0, 0, true);
     m.insert(0, 1, true);
@@ -457,7 +423,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return a matrix containing the normalized columns
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(0, 2, true);
@@ -481,7 +447,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should symmetrize the matrix
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -503,8 +469,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<int, bool> m(3, 3);
-    SparseMatrix<int, bool> m2(3, 4);
+    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m2(3, 4);
     CHECK_THROWS(m + m2);
   }
   SUBCASE("+ operator") {
@@ -514,11 +480,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should sum the two matrices
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
-    SparseMatrix<int, bool> m2(3, 3);
+    SparseMatrix<uint32_t, bool> m2(3, 3);
     m2.insert(0, 0, true);
     m2.insert(1, 0, true);
     m2.insert(2, 1, true);
@@ -539,8 +505,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<int, bool> m(3, 3);
-    SparseMatrix<int, bool> m2(3, 4);
+    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m2(3, 4);
     CHECK_THROWS(m += m2);
   }
   SUBCASE("+= operator") {
@@ -550,11 +516,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should sum the two matrices
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
-    SparseMatrix<int, bool> m2(3, 3);
+    SparseMatrix<uint32_t, bool> m2(3, 3);
     m2.insert(0, 0, true);
     m2.insert(1, 0, true);
     m2.insert(2, 1, true);
@@ -575,8 +541,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<int, bool> m(3, 3);
-    SparseMatrix<int, bool> m2(3, 4);
+    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m2(3, 4);
     CHECK_THROWS(m - m2);
   }
   SUBCASE("- operator") {
@@ -586,11 +552,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should subtract the two matrices
     */
-    SparseMatrix<int, int> m(3, 3);
+    SparseMatrix<uint32_t, int> m(3, 3);
     m.insert(0, 0, 1);
     m.insert(0, 1, 2);
     m.insert(1, 2, 3);
-    SparseMatrix<int, int> m2(3, 3);
+    SparseMatrix<uint32_t, int> m2(3, 3);
     m2.insert(0, 0, 1);
     m2.insert(1, 0, 2);
     m2.insert(2, 1, 3);
@@ -611,8 +577,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<int, bool> m(3, 3);
-    SparseMatrix<int, bool> m2(3, 4);
+    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m2(3, 4);
     CHECK_THROWS(m -= m2);
   }
   SUBCASE("-= operator") {
@@ -622,11 +588,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should subtract the two matrices
     */
-    SparseMatrix<int, int> m(3, 3);
+    SparseMatrix<uint32_t, int> m(3, 3);
     m.insert(0, 0, 1);
     m.insert(0, 1, 2);
     m.insert(1, 2, 3);
-    SparseMatrix<int, int> m2(3, 3);
+    SparseMatrix<uint32_t, int> m2(3, 3);
     m2.insert(0, 0, 1);
     m2.insert(1, 0, 2);
     m2.insert(2, 1, 3);
@@ -646,8 +612,8 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a non-square matrix
     THEN: the function should throw an exception
     */
-    SparseMatrix<int, double> m(4, 3);
-    SparseMatrix<int, double> m2(3, 4);
+    SparseMatrix<uint32_t, double> m(4, 3);
+    SparseMatrix<uint32_t, double> m2(3, 4);
     CHECK_THROWS(m.getStrengthVector());
     CHECK_THROWS(m2.getStrengthVector());
   }
@@ -659,7 +625,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a street with 1 vehicle and length 10
     THEN: the function should return a vector with 0.1
     */
-    SparseMatrix<int, double> m(3, 3);
+    SparseMatrix<uint32_t, double> m(3, 3);
     m.insert(0, 0, 0.3);
     m.insert(0, 1, 0.3);
     m.insert(0, 2, 0.1);
@@ -679,7 +645,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a non-square matrix
     THEN: the function should throw an exception
     */
-    SparseMatrix<int, double> m(4, 3);
+    SparseMatrix<uint32_t, double> m(4, 3);
     CHECK_THROWS(m.getLaplacian());
   }
   SUBCASE("getLaplacian") {
@@ -689,7 +655,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the Laplacian matrix of the matrix
     */
-    SparseMatrix<int, bool> m(3, 3);
+    SparseMatrix<uint32_t, bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);


### PR DESCRIPTION
* Define `is_numeric_v` type traits, which check that a template paramenter is either an integral or a floating point type (Note: we can't use `std::is_arithmetic` because it inlcudes `bool` and `char`, which are unfit to be indexes of a matrix)
* Add constaints on all the template parameters using `type_traits` and C++20 `requires`
* Fix missing includes in `TypeTraits.hpp`
* Fix index types in tests of `SparseMatrix`
* Remove unneeded tests of `SparseMatrix`