### PR TITLE
Feature street missing methods

### DIFF
--- a/src/Itinerary.hpp
+++ b/src/Itinerary.hpp
@@ -14,7 +14,7 @@ namespace dmf {
     std::pair<Id, Id> m_trip;
 
   public:
-	Itinerary() = default;
+    Itinerary() = default;
     Itinerary(Id source, Id destination) : m_trip{std::make_pair(source, destination)} {}
     explicit Itinerary(std::pair<Id, Id> trip) : m_trip{std::move(trip)} {}
 

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -9,6 +9,7 @@
 
 #include "Agent.hpp"
 #include "Node.hpp"
+#include "utility/TypeTraits.hpp"
 
 namespace dmf {
 
@@ -45,7 +46,7 @@ namespace dmf {
     const std::pair<Id, Id>& nodePair() const;
 
     template <typename Weight>
-      requires is_numeric_v<Weight>
+      /* requires is_numeric_v<Weight> */
     void enqueue(const Agent<Id, Weight>& agent);
 	std::optional<Id> dequeue();
   };
@@ -127,10 +128,10 @@ namespace dmf {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   template <typename Weight>
-    requires is_numeric_v<Weight>
+    /* requires is_numeric_v<Weight> */
   void Street<Id, Size>::enqueue(const Agent<Id, Weight>& agent) {
     if (m_size < m_capacity) {
-      m_queue.enqueue(agent.index());
+      m_queue.push(agent.index());
       ++m_size;
     }
   }
@@ -140,7 +141,7 @@ namespace dmf {
   std::optional<Id> Street<Id, Size>::dequeue() {
 	if (m_size > 0) {
 	  Id res{m_queue.front()};
-	  m_queue.dequeue();
+	  m_queue.pop();
 	  --m_size;
 
 	  return res;

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "Agent.hpp"
 #include "Node.hpp"
 
 namespace dmf {
@@ -27,11 +28,12 @@ namespace dmf {
     Street(Id index, Size size, Size capacity, double len);
 
     // Setters
+    void setId(Id id);
     void setCapacity(Size capacity);
     void setLength(double len);
     void setQueue(std::queue<Size> queue);
-	void setNodePair(const Node<Id>& node1, const Node<Id>& node2);
-	void setNodePair(std::pair<Id, Id> pair);
+    void setNodePair(const Node<Id>& node1, const Node<Id>& node2);
+    void setNodePair(std::pair<Id, Id> pair);
 
     // Getters
     Id id() const;
@@ -40,6 +42,11 @@ namespace dmf {
     double length() const;
     const std::queue<Size>& queue() const;
     const std::pair<Id, Id>& nodePair() const;
+
+    template <typename Weight>
+      requires is_numeric_v<Weight>
+    void enqueue(const Agent<Id, Weight>& agent);
+    Id dequeue();
   };
 
   template <typename Id, typename Size>
@@ -53,6 +60,11 @@ namespace dmf {
       : m_id{index}, m_size{size}, m_capacity{capacity}, m_len{len} {}
 
   // Setters
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Street<Id, Size>::setId(Id id) {
+    m_id = id;
+  }
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Street<Id, Size>::setCapacity(Size capacity) {
@@ -71,12 +83,12 @@ namespace dmf {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Street<Id, Size>::setNodePair(const Node<Id>& node1, const Node<Id>& node2) {
-	m_nodePair = std::make_pair(node1, node2);
+    m_nodePair = std::make_pair(node1, node2);
   }
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Street<Id, Size>::setNodePair(std::pair<Id, Id> pair) {
-	m_nodePair = std::move(pair);
+    m_nodePair = std::move(pair);
   }
 
   // Getters
@@ -110,6 +122,28 @@ namespace dmf {
   const std::pair<Id, Id>& Street<Id, Size>::nodePair() const {
     return m_nodePair;
   }
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  template <typename Weight>
+    requires is_numeric_v<Weight>
+  void Street<Id, Size>::enqueue(const Agent<Id, Weight>& agent) {
+    if (m_size < m_capacity) {
+      m_queue.enqueue(agent.index());
+      ++m_size;
+    }
+  }
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  Id Street<Id, Size>::dequeue() {
+    Id res{m_queue.front()};
+    m_queue.dequeue();
+    --m_size;
+
+    return res;
+  }
+
 };  // namespace dmf
 
 #endif

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -3,6 +3,7 @@
 #define Street_hpp
 
 #include <queue>
+#include <type_traits>
 #include <utility>
 
 namespace dmf {

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -34,7 +34,7 @@ namespace dmf {
     void setCapacity(Size capacity);
     void setLength(double len);
     void setQueue(std::queue<Size> queue);
-	void setNodePair(Id node1, Id node2);
+    void setNodePair(Id node1, Id node2);
     void setNodePair(const Node<Id>& node1, const Node<Id>& node2);
     void setNodePair(std::pair<Id, Id> pair);
 
@@ -47,9 +47,9 @@ namespace dmf {
     const std::pair<Id, Id>& nodePair() const;
 
     template <typename Weight>
-      /* requires is_numeric_v<Weight> */
+    /* requires is_numeric_v<Weight> */
     void enqueue(const Agent<Id, Weight>& agent);
-	std::optional<Id> dequeue();
+    std::optional<Id> dequeue();
   };
 
   template <typename Id, typename Size>
@@ -134,7 +134,7 @@ namespace dmf {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   template <typename Weight>
-    /* requires is_numeric_v<Weight> */
+  /* requires is_numeric_v<Weight> */
   void Street<Id, Size>::enqueue(const Agent<Id, Weight>& agent) {
     if (m_size < m_capacity) {
       m_queue.push(agent.index());
@@ -145,15 +145,15 @@ namespace dmf {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   std::optional<Id> Street<Id, Size>::dequeue() {
-	if (m_size > 0) {
-	  Id res{m_queue.front()};
-	  m_queue.pop();
-	  --m_size;
+    if (m_size > 0) {
+      Id res{m_queue.front()};
+      m_queue.pop();
+      --m_size;
 
-	  return res;
-	}
+      return res;
+    }
 
-	return std::nullopt;
+    return std::nullopt;
   }
 
 };  // namespace dmf

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -27,6 +27,7 @@ namespace dmf {
   public:
     Street() = default;
     Street(Id index, Size capacity, double len);
+    Street(Id index, Size capacity, double len, std::pair<Id, Id> nodePair);
     Street(Id index, Size size, Size capacity, double len);
 
     // Setters
@@ -55,6 +56,11 @@ namespace dmf {
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Street<Id, Size>::Street(Id index, Size capacity, double len)
       : m_id{index}, m_capacity{capacity}, m_len{len} {}
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  Street<Id, Size>::Street(Id index, Size capacity, double len, std::pair<Id, Id> nodePair)
+      : m_id{index}, m_capacity{capacity}, m_len{len}, m_nodePair{std::move(nodePair)} {}
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -6,6 +6,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "Node.hpp"
+
 namespace dmf {
 
   template <typename Id, typename Size>
@@ -28,6 +30,8 @@ namespace dmf {
     void setCapacity(Size capacity);
     void setLength(double len);
     void setQueue(std::queue<Size> queue);
+	void setNodePair(const Node<Id>& node1, const Node<Id>& node2);
+	void setNodePair(std::pair<Id, Id> pair);
 
     // Getters
     Id id() const;
@@ -63,6 +67,16 @@ namespace dmf {
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Street<Id, Size>::setQueue(std::queue<Size> queue) {
     m_queue = std::move(queue);
+  }
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Street<Id, Size>::setNodePair(const Node<Id>& node1, const Node<Id>& node2) {
+	m_nodePair = std::make_pair(node1, node2);
+  }
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Street<Id, Size>::setNodePair(std::pair<Id, Id> pair) {
+	m_nodePair = std::move(pair);
   }
 
   // Getters

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -2,6 +2,7 @@
 #ifndef Street_hpp
 #define Street_hpp
 
+#include <optional>
 #include <queue>
 #include <type_traits>
 #include <utility>
@@ -46,7 +47,7 @@ namespace dmf {
     template <typename Weight>
       requires is_numeric_v<Weight>
     void enqueue(const Agent<Id, Weight>& agent);
-    Id dequeue();
+	std::optional<Id> dequeue();
   };
 
   template <typename Id, typename Size>
@@ -136,12 +137,16 @@ namespace dmf {
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Id Street<Id, Size>::dequeue() {
-    Id res{m_queue.front()};
-    m_queue.dequeue();
-    --m_size;
+  std::optional<Id> Street<Id, Size>::dequeue() {
+	if (m_size > 0) {
+	  Id res{m_queue.front()};
+	  m_queue.dequeue();
+	  --m_size;
 
-    return res;
+	  return res;
+	}
+
+	return std::nullopt;
   }
 
 };  // namespace dmf

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -28,7 +28,6 @@ namespace dmf {
     Street() = default;
     Street(Id index, Size capacity, double len);
     Street(Id index, Size capacity, double len, std::pair<Id, Id> nodePair);
-    Street(Id index, Size size, Size capacity, double len);
 
     // Setters
     void setId(Id id);
@@ -61,11 +60,6 @@ namespace dmf {
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Street<Id, Size>::Street(Id index, Size capacity, double len, std::pair<Id, Id> nodePair)
       : m_id{index}, m_capacity{capacity}, m_len{len}, m_nodePair{std::move(nodePair)} {}
-
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(Id index, Size size, Size capacity, double len)
-      : m_id{index}, m_size{size}, m_capacity{capacity}, m_len{len} {}
 
   // Setters
   template <typename Id, typename Size>

--- a/src/Street.hpp
+++ b/src/Street.hpp
@@ -34,6 +34,7 @@ namespace dmf {
     void setCapacity(Size capacity);
     void setLength(double len);
     void setQueue(std::queue<Size> queue);
+	void setNodePair(Id node1, Id node2);
     void setNodePair(const Node<Id>& node1, const Node<Id>& node2);
     void setNodePair(std::pair<Id, Id> pair);
 
@@ -84,8 +85,13 @@ namespace dmf {
   }
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::setNodePair(const Node<Id>& node1, const Node<Id>& node2) {
+  void Street<Id, Size>::setNodePair(Id node1, Id node2) {
     m_nodePair = std::make_pair(node1, node2);
+  }
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Street<Id, Size>::setNodePair(const Node<Id>& node1, const Node<Id>& node2) {
+    m_nodePair = std::make_pair(node1.id(), node2.id());
   }
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)

--- a/src/utility/TypeTraits.hpp
+++ b/src/utility/TypeTraits.hpp
@@ -5,10 +5,15 @@
 #include <memory>
 #include <type_traits>
 
-#include "../Node.hpp"
-#include "../Street.hpp"
-
 namespace dmf {
+  template <typename Id>
+    requires std::unsigned_integral<Id>
+  class Node;
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  class Street;
+
   // Alias for shared pointers
   template <typename T>
   using shared = std::shared_ptr<T>;

--- a/test/Street/Test_street.cpp
+++ b/test/Street/Test_street.cpp
@@ -1,23 +1,127 @@
 
 #include <cstdint>
+#include <optional>
 
+#include "Agent.hpp"
+#include "Node.hpp"
 #include "Street.hpp"
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
+using Agent = dmf::Agent<uint16_t, float>;
+using Node = dmf::Node<uint16_t>;
 using Street = dmf::Street<uint16_t, uint16_t>;
 
 TEST_CASE("Street") {
-  SUBCASE("Constructor") {
+  SUBCASE("Constructor_1") {
     /*This tests the constructor that takes an Id, capacity, and length.
     GIVEN: An Id, capacity, and length
     WHEN: A Street is constructed
     THEN: The Id, capacity, and length are set correctly
     */
+
     Street street{1, 2, 3.5};
-    CHECK(street.id() == 1);
-    CHECK(street.capacity() == 2);
-    CHECK(street.length() == 3.5);
+    CHECK_EQ(street.id(), 1);
+    CHECK_EQ(street.capacity(), 2);
+    CHECK_EQ(street.length(), 3.5);
+	CHECK_EQ(street.nodePair(), std::pair<uint16_t, uint16_t>());
+  }
+
+  SUBCASE("Constructor_2") {
+    /*This tests the constructor that takes an Id, capacity, length, and nodePair.
+    GIVEN: An Id, capacity, length and nodePair
+    WHEN: A Street is constructed
+    THEN: The Id, capacity, length and nodePair are set correctly
+    */
+
+    Street street{1, 2, 3.5, std::make_pair(4, 5)};
+    CHECK_EQ(street.id(), 1);
+    CHECK_EQ(street.capacity(), 2);
+    CHECK_EQ(street.length(), 3.5);
+	CHECK_EQ(street.nodePair().first, 4);
+	CHECK_EQ(street.nodePair().second, 5);
+  }
+
+  SUBCASE("SetNodePair_1") {
+    /*This tests the setNodePair method*/
+
+    Street street{1, 2, 3.5};
+    street.setNodePair(4, 5);
+    CHECK_EQ(street.nodePair().first, 4);
+    CHECK_EQ(street.nodePair().second, 5);
+  }
+
+  SUBCASE("SetNodePair_2") {
+    /*This tests the setNodePair method*/
+
+    Street street{1, 2, 3.5};
+	Node node1{4};
+	Node node2{5};
+    street.setNodePair(node1, node2);
+    CHECK_EQ(street.nodePair().first, 4);
+    CHECK_EQ(street.nodePair().second, 5);
+  }
+
+  SUBCASE("SetNodePair_3") {
+    /*This tests the setNodePair method*/
+
+    Street street{1, 2, 3.5};
+    street.setNodePair(std::make_pair(4, 5));
+    CHECK_EQ(street.nodePair().first, 4);
+    CHECK_EQ(street.nodePair().second, 5);
+  }
+
+  SUBCASE("Enqueue") {
+    /*This tests the insertion of an agent in a street's queue*/
+
+    // define some agents
+    Agent a1{1, 1};  // they are all in street 1
+    Agent a2{2, 1};
+    Agent a3{3, 1};
+    Agent a4{4, 1};
+
+    Street street{1, 4, 3.5};
+    // fill the queue
+    street.enqueue(a1);
+    street.enqueue(a2);
+    street.enqueue(a3);
+    street.enqueue(a4);
+    CHECK_EQ(street.queue().front(), 1);
+    CHECK_EQ(street.queue().back(), 4);
+    CHECK_EQ(street.queue().size(), street.capacity());
+    CHECK_EQ(street.size(), street.capacity());
+  }
+
+  SUBCASE("Dequeue") {
+    /*This tests the exit of an agent from a street's queue*/
+
+    // define some agents
+    Agent a1{1, 1};  // they are all in street 1
+    Agent a2{2, 1};
+    Agent a3{3, 1};
+    Agent a4{4, 1};
+
+    Street street{1, 4, 3.5};
+    // fill the queue
+    street.enqueue(a1);
+    street.enqueue(a2);
+    street.enqueue(a3);
+    street.enqueue(a4);
+    CHECK_EQ(street.queue().front(), 1);  // check that agent 1 is at the front of the queue
+
+    // dequeue
+    street.dequeue();
+    CHECK_EQ(street.queue().front(), 2);  // check that agent 2 is now at front
+    // check that the length of the queue has decreased
+    CHECK_EQ(street.queue().size(), 3);
+    CHECK_EQ(street.size(), 3);
+    // check that the next agent dequeued is agent 2
+    CHECK_EQ(street.dequeue().value(), 2);
+    CHECK_EQ(street.size(), 2);
+    street.dequeue();
+    street.dequeue();  // the queue is now empty
+    // check that the result of dequeue is std::nullopt
+    CHECK_FALSE(street.dequeue().has_value());
   }
 }

--- a/test/Street/Test_street.cpp
+++ b/test/Street/Test_street.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Street") {
     CHECK_EQ(street.id(), 1);
     CHECK_EQ(street.capacity(), 2);
     CHECK_EQ(street.length(), 3.5);
-	CHECK_EQ(street.nodePair(), std::pair<uint16_t, uint16_t>());
+    CHECK_EQ(street.nodePair(), std::pair<uint16_t, uint16_t>());
   }
 
   SUBCASE("Constructor_2") {
@@ -39,8 +39,8 @@ TEST_CASE("Street") {
     CHECK_EQ(street.id(), 1);
     CHECK_EQ(street.capacity(), 2);
     CHECK_EQ(street.length(), 3.5);
-	CHECK_EQ(street.nodePair().first, 4);
-	CHECK_EQ(street.nodePair().second, 5);
+    CHECK_EQ(street.nodePair().first, 4);
+    CHECK_EQ(street.nodePair().second, 5);
   }
 
   SUBCASE("SetNodePair_1") {
@@ -56,8 +56,8 @@ TEST_CASE("Street") {
     /*This tests the setNodePair method*/
 
     Street street{1, 2, 3.5};
-	Node node1{4};
-	Node node2{5};
+    Node node1{4};
+    Node node2{5};
     street.setNodePair(node1, node2);
     CHECK_EQ(street.nodePair().first, 4);
     CHECK_EQ(street.nodePair().second, 5);


### PR DESCRIPTION
This PR updates the `Street` class, adding some missing core methods (issue #21).
* add `setNodePair` methods
* add constructor accepting a nodePair
* remove useless constructor taking the size parameter
* add `enqueue` and `dequeue` methods for the Street's `queue` member
* add tests for all the constructors, overloads of `setNodePair` and `enqueue`/`dequeue` methods