### PR TITLE
Rework of `Agent` class

### DIFF
--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -107,16 +107,14 @@ namespace dsm {
     m_streetId = streetId;
   }
 
-  template <typename Id, typename Size>
+  template <typename Id, typename Size, typename Delay>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
   void Agent<Id, Size, Delay>::setItinerary(Itinerary<Id> itinerary) {
     m_itinerary = std::move(itinerary);
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
   void Agent<Id, Size, Delay>::setSpeed(double speed) {
     if (speed < 0) {
       std::string errorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -26,24 +26,24 @@ namespace dsm {
     Itinerary<Id> m_itinerary;
     double m_speed;
     Id m_index;
-    Id m_position;
+    Id m_streetId;
     unsigned int m_time;
 
   public:
     Agent() = default;
     /// @brief Construct a new Agent object
     /// @param index, The agent's id
-    /// @param position, The agent's position
-    Agent(Id index, Id position);
+    /// @param streetId, The id of the street currently occupied by the agent
+    Agent(Id index, Id streetId);
     /// @brief Construct a new Agent object
     /// @param index, The agent's id
-    /// @param position, The agent's position
+    /// @param streetId, The id of the street currently occupied by the agent
     /// @param itinerary, The agent's itinerary
-    Agent(Id index, Id position, Itinerary<Id> itinerary);
+    Agent(Id index, Id streetId, Itinerary<Id> itinerary);
 
-    /// @brief Set the agent's position
-    /// @param position, The agent's position
-    void setPosition(Id position);
+    /// @brief Set the street occupied by the agent
+    /// @param streetId, The id of the street currently occupied by the agent
+    void setPosition(Id streetId);
     /// @brief Set the agent's itinerary
     /// @param itinerary, The agent's itinerary
     void setItinerary(Itinerary<Id> itinerary);
@@ -64,9 +64,9 @@ namespace dsm {
     /// @brief Get the agent's id
     /// @return The agent's id
     Id index() const;
-    /// @brief Get the agent's position
-    /// @return The agent's position
-    Id position() const;
+    /// @brief Get the id of the street currently occupied by the agent
+    /// @return The id of the street currently occupied by the agent
+    Id streetId() const;
     /// @brief Get the agent's itinerary
     /// @return The agent's itinerary
     const Itinerary<Id>& itinerary() const;
@@ -80,22 +80,22 @@ namespace dsm {
 
   template <typename Id>
     requires std::unsigned_integral<Id>
-  Agent<Id>::Agent(Id index, Id position)
-      : m_speed{0.}, m_index{index}, m_position{position}, m_time{0} {}
+  Agent<Id>::Agent(Id index, Id streetId)
+      : m_speed{0.}, m_index{index}, m_streetId{streetId}, m_time{0} {}
 
   template <typename Id>
     requires std::unsigned_integral<Id>
-  Agent<Id>::Agent(Id index, Id position, Itinerary<Id> itinerary)
+  Agent<Id>::Agent(Id index, Id streetId, Itinerary<Id> itinerary)
       : m_itinerary{std::move(itinerary)},
         m_speed{0.},
         m_index{index},
-        m_position{position},
+        m_streetId{streetId},
         m_time{0} {}
 
   template <typename Id>
     requires std::unsigned_integral<Id>
-  void Agent<Id>::setPosition(Id position) {
-    m_position = position;
+  void Agent<Id>::setPosition(Id streetId) {
+    m_streetId = streetId;
   }
   template <typename Id>
     requires std::unsigned_integral<Id>
@@ -140,8 +140,8 @@ namespace dsm {
   }
   template <typename Id>
     requires std::unsigned_integral<Id>
-  Id Agent<Id>::position() const {
-    return m_position;
+  Id Agent<Id>::streetId() const {
+    return m_streetId;
   }
   template <typename Id>
     requires std::unsigned_integral<Id>

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -3,7 +3,7 @@
 ///
 /// @details    This file contains the definition of the Agent class.
 ///             The Agent class represents an agent in the network. It is templated by the type
-///             of the agent's id. The agent's id must be an unsigned integral type.
+///             of the agent's id and the size of agents, which must both be unsigned integrals.
 
 #ifndef Agent_hpp
 #define Agent_hpp
@@ -12,15 +12,17 @@
 #include "SparseMatrix.hpp"
 #include "../utility/TypeTraits/is_numeric.hpp"
 
+#include <concepts>
 #include <stdexcept>
 #include <string>
 #include <limits>
 
 namespace dsm {
   /// @brief The Agent class represents an agent in the network.
-  /// @tparam Id The type of the agent's id. It must be an unsigned integral type.
-  template <typename Id>
-    requires std::unsigned_integral<Id>
+  /// @tparam Id, The type of the agent's id. It must be an unsigned integral type.
+  /// @tparam Size, The type of the size of a street. It must be an unsigned integral type.
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Agent {
   private:
     Itinerary<Id> m_itinerary;
@@ -78,33 +80,35 @@ namespace dsm {
     unsigned int time() const;
   };
 
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  Agent<Id>::Agent(Id index, Id streetId)
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  Agent<Id, Size>::Agent(Id index, Id streetId)
       : m_speed{0.}, m_index{index}, m_streetId{streetId}, m_time{0} {}
 
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  Agent<Id>::Agent(Id index, Id streetId, Itinerary<Id> itinerary)
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  Agent<Id, Size>::Agent(Id index, Id streetId, Itinerary<Id> itinerary)
       : m_itinerary{std::move(itinerary)},
         m_speed{0.},
         m_index{index},
         m_streetId{streetId},
         m_time{0} {}
 
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  void Agent<Id>::setPosition(Id streetId) {
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Agent<Id, Size>::setPosition(Id streetId) {
     m_streetId = streetId;
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  void Agent<Id>::setItinerary(Itinerary<Id> itinerary) {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Agent<Id, Size>::setItinerary(Itinerary<Id> itinerary) {
     m_itinerary = std::move(itinerary);
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  void Agent<Id>::setSpeed(double speed) {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Agent<Id, Size>::setSpeed(double speed) {
     if (speed < 0) {
       std::string errorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
                              "Speed must be positive";
@@ -112,9 +116,10 @@ namespace dsm {
     }
     m_speed = speed;
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  void Agent<Id>::incrementTime() {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Agent<Id, Size>::incrementTime() {
     if (m_time == std::numeric_limits<unsigned int>::max()) {
       std::string errorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
                              "Time has reached its maximum value";
@@ -122,9 +127,10 @@ namespace dsm {
     }
     ++m_time;
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  void Agent<Id>::incrementTime(unsigned int time) {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  void Agent<Id, Size>::incrementTime(unsigned int time) {
     if (m_time + time < m_time) {
       std::string errorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
                              "Time has reached its maximum value";
@@ -133,29 +139,33 @@ namespace dsm {
     m_time += time;
   }
 
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  Id Agent<Id>::index() const {
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  Id Agent<Id, Size>::index() const {
     return m_index;
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  Id Agent<Id>::streetId() const {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  Id Agent<Id, Size>::streetId() const {
     return m_streetId;
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  double Agent<Id>::speed() const {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  double Agent<Id, Size>::speed() const {
     return m_speed;
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  unsigned int Agent<Id>::time() const {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  unsigned int Agent<Id, Size>::time() const {
     return m_time;
   }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  const Itinerary<Id>& Agent<Id>::itinerary() const {
+
+  template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  const Itinerary<Id>& Agent<Id, Size>::itinerary() const {
     return m_itinerary;
   }
 };  // namespace dsm

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -45,7 +45,7 @@ namespace dsm {
 
     /// @brief Set the street occupied by the agent
     /// @param streetId, The id of the street currently occupied by the agent
-    void setPosition(Id streetId);
+    void setStreetId(Id streetId);
     /// @brief Set the agent's itinerary
     /// @param itinerary, The agent's itinerary
     void setItinerary(Itinerary<Id> itinerary);
@@ -96,7 +96,7 @@ namespace dsm {
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Agent<Id, Size>::setPosition(Id streetId) {
+  void Agent<Id, Size>::setStreetId(Id streetId) {
     m_streetId = streetId;
   }
 

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -4,9 +4,9 @@
 /// @details    This file contains the definition of the Agent class.
 ///             The Agent class represents an agent in the network. It is templated by the type
 ///             of the agent's id and the size of agents, which must both be unsigned integrals.
-///				It is also templated by the Delay type, which must be a numeric (see utility/TypeTraits/is_numeric.hpp)
-///				and represents the spatial or temporal (depending on the type of the template) distance
-///				between the agent and the one in front of it.
+///				      It is also templated by the Delay type, which must be a numeric (see utility/TypeTraits/is_numeric.hpp)
+///				      and represents the spatial or temporal (depending on the type of the template) distance
+///				      between the agent and the one in front of it.
 
 #ifndef Agent_hpp
 #define Agent_hpp
@@ -26,7 +26,7 @@ namespace dsm {
   /// @tparam Size, The type of the size of a street. It must be an unsigned integral type.
   /// @tparam Delay, The type of the agent's delay. It must be a numeric type (see utility/TypeTraits/is_numeric.hpp).
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>
   class Agent {
   private:
     Itinerary<Id> m_itinerary;

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -27,7 +27,6 @@ namespace dsm {
     double m_speed;
     Id m_index;
     Id m_position;
-    Id m_previousPosition;
     unsigned int m_time;
 
   public:
@@ -68,9 +67,6 @@ namespace dsm {
     /// @brief Get the agent's position
     /// @return The agent's position
     Id position() const;
-    /// @brief Get the agent's previous position
-    /// @return The agent's previous position
-    Id previousPosition() const;
     /// @brief Get the agent's itinerary
     /// @return The agent's itinerary
     const Itinerary<Id>& itinerary() const;
@@ -85,7 +81,7 @@ namespace dsm {
   template <typename Id>
     requires std::unsigned_integral<Id>
   Agent<Id>::Agent(Id index, Id position)
-      : m_speed{0.}, m_index{index}, m_position{position}, m_previousPosition{position}, m_time{0} {}
+      : m_speed{0.}, m_index{index}, m_position{position}, m_time{0} {}
 
   template <typename Id>
     requires std::unsigned_integral<Id>
@@ -94,7 +90,6 @@ namespace dsm {
         m_speed{0.},
         m_index{index},
         m_position{position},
-        m_previousPosition{position},
         m_time{0} {}
 
   template <typename Id>
@@ -147,11 +142,6 @@ namespace dsm {
     requires std::unsigned_integral<Id>
   Id Agent<Id>::position() const {
     return m_position;
-  }
-  template <typename Id>
-    requires std::unsigned_integral<Id>
-  Id Agent<Id>::previousPosition() const {
-    return m_previousPosition;
   }
   template <typename Id>
     requires std::unsigned_integral<Id>

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -4,6 +4,9 @@
 /// @details    This file contains the definition of the Agent class.
 ///             The Agent class represents an agent in the network. It is templated by the type
 ///             of the agent's id and the size of agents, which must both be unsigned integrals.
+///				It is also templated by the Delay type, which must be a numeric (see utility/TypeTraits/is_numeric.hpp)
+///				and represents the spatial or temporal (depending on the type of the template) distance
+///				between the agent and the one in front of it.
 
 #ifndef Agent_hpp
 #define Agent_hpp
@@ -21,12 +24,14 @@ namespace dsm {
   /// @brief The Agent class represents an agent in the network.
   /// @tparam Id, The type of the agent's id. It must be an unsigned integral type.
   /// @tparam Size, The type of the size of a street. It must be an unsigned integral type.
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+  /// @tparam Delay, The type of the agent's delay. It must be a numeric type (see utility/TypeTraits/is_numeric.hpp).
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
   class Agent {
   private:
     Itinerary<Id> m_itinerary;
     double m_speed;
+    Delay m_delay;
     Id m_index;
     Id m_streetId;
     unsigned int m_time;
@@ -53,6 +58,9 @@ namespace dsm {
     /// @param speed, The agent's speed
     /// @throw std::invalid_argument, if speed is negative
     void setSpeed(double speed);
+    /// @brief Set the agent's delay
+    /// @param delay, The agent's delay
+    void setDelay(Delay delay);
     /// @brief Increment the agent's time by 1
     /// @throw std::overflow_error, if time has reached its maximum value
     void incrementTime();
@@ -75,40 +83,41 @@ namespace dsm {
     /// @brief Get the agent's speed
     /// @return The agent's speed
     double speed() const;
+    /// @brief Get the agent's delay
+    /// @return	The agent's delay
+    Delay delay() const;
     /// @brief Get the agent's travel time
     /// @return The agent's travel time
     unsigned int time() const;
   };
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Agent<Id, Size>::Agent(Id index, Id streetId)
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  Agent<Id, Size, Delay>::Agent(Id index, Id streetId)
       : m_speed{0.}, m_index{index}, m_streetId{streetId}, m_time{0} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Agent<Id, Size>::Agent(Id index, Id streetId, Itinerary<Id> itinerary)
-      : m_itinerary{std::move(itinerary)},
-        m_speed{0.},
-        m_index{index},
-        m_streetId{streetId},
-        m_time{0} {}
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  Agent<Id, Size, Delay>::Agent(Id index, Id streetId, Itinerary<Id> itinerary)
+      : m_itinerary{std::move(itinerary)}, m_speed{0.}, m_index{index}, m_streetId{streetId}, m_time{0} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Agent<Id, Size>::setStreetId(Id streetId) {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  void Agent<Id, Size, Delay>::setStreetId(Id streetId) {
     m_streetId = streetId;
   }
 
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Agent<Id, Size>::setItinerary(Itinerary<Id> itinerary) {
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  void Agent<Id, Size, Delay>::setItinerary(Itinerary<Id> itinerary) {
     m_itinerary = std::move(itinerary);
   }
 
   template <typename Id, typename Size>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  template <typename Id, typename Size, typename Delay>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Agent<Id, Size>::setSpeed(double speed) {
+  void Agent<Id, Size, Delay>::setSpeed(double speed) {
     if (speed < 0) {
       std::string errorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
                              "Speed must be positive";
@@ -117,9 +126,15 @@ namespace dsm {
     m_speed = speed;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Agent<Id, Size>::incrementTime() {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  void Agent<Id, Size, Delay>::setDelay(Delay delay) {
+    m_delay = delay;
+  }
+
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  void Agent<Id, Size, Delay>::incrementTime() {
     if (m_time == std::numeric_limits<unsigned int>::max()) {
       std::string errorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
                              "Time has reached its maximum value";
@@ -128,9 +143,9 @@ namespace dsm {
     ++m_time;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Agent<Id, Size>::incrementTime(unsigned int time) {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  void Agent<Id, Size, Delay>::incrementTime(unsigned int time) {
     if (m_time + time < m_time) {
       std::string errorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
                              "Time has reached its maximum value";
@@ -139,33 +154,39 @@ namespace dsm {
     m_time += time;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Id Agent<Id, Size>::index() const {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  Id Agent<Id, Size, Delay>::index() const {
     return m_index;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Id Agent<Id, Size>::streetId() const {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  Id Agent<Id, Size, Delay>::streetId() const {
     return m_streetId;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  double Agent<Id, Size>::speed() const {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  double Agent<Id, Size, Delay>::speed() const {
     return m_speed;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  unsigned int Agent<Id, Size>::time() const {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  Delay Agent<Id, Size, Delay>::delay() const {
+    return m_delay;
+  }
+
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  unsigned int Agent<Id, Size, Delay>::time() const {
     return m_time;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  const Itinerary<Id>& Agent<Id, Size>::itinerary() const {
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> && is_numeric_v<Delay>)
+  const Itinerary<Id>& Agent<Id, Size, Delay>::itinerary() const {
     return m_itinerary;
   }
 };  // namespace dsm

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -114,7 +114,8 @@ namespace dsm {
     double maxSpeed() const;
     /// @brief Add an agent to the street's queue
     /// @param agent, The agent to add
-    void enqueue(const Agent<Id>& agent);
+	template <typename Delay>
+    void enqueue(const Agent<Id, Size, Delay>& agent);
     /// @brief Remove an agent from the street's queue
     std::optional<Id> dequeue();
   };
@@ -234,7 +235,8 @@ namespace dsm {
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::enqueue(const Agent<Id>& agent) {
+  template <typename Delay>
+  void Street<Id, Size>::enqueue(const Agent<Id, Size, Delay>& agent) {
     if (m_size < m_capacity) {
       m_queue.push(agent.index());
       ++m_size;

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -114,7 +114,7 @@ namespace dsm {
     double maxSpeed() const;
     /// @brief Add an agent to the street's queue
     /// @param agent, The agent to add
-	template <typename Delay>
+    template <typename Delay>
     void enqueue(const Agent<Id, Size, Delay>& agent);
     /// @brief Remove an agent from the street's queue
     std::optional<Id> dequeue();

--- a/test/Street/Test_street.cpp
+++ b/test/Street/Test_street.cpp
@@ -9,7 +9,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-using Agent = dsm::Agent<uint16_t>;
+using Agent = dsm::Agent<uint16_t, uint16_t, double>;
 using Node = dsm::Node<uint16_t>;
 using Street = dsm::Street<uint16_t, uint16_t>;
 


### PR DESCRIPTION
This PR implements some major changes to the structure of the `Agent` class:
* add `Size` template parameter for the size of the street occupied by the Agent
* remove the `m_previousPosition` data member because it is mostly useless
* rename the `m_position` data member as `m_streetId`
* add `Delay` template parameter and `m_delay` data member, representing the spatial or temporal distance between the agent and the one in front of it