### PR TITLE
Add nodes to nodeSet when using `addStreet`

### DIFF
--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -225,13 +225,25 @@ namespace dsm {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addStreet(shared<Street<Id, Size>> street) {
+	// insert street
     m_streets.insert(std::make_pair(street->id(), street));
+	// insert nodes
+	const Id node1{street.nodePair().first};
+	const Id node2{street.nodePair().second};
+	m_nodes.insert_or_assign(node1);
+	m_nodes.insert_or_assign(node2);
   }
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addStreet(const Street<Id, Size>& street) {
+	// insert street
     m_streets.insert(std::make_pair(street.id(), make_shared<Street<Id, Size>>(street)));
+	// insert nodes
+	const Id node1{street.nodePair().first};
+	const Id node2{street.nodePair().second};
+	m_nodes.insert_or_assign(node1, make_shared<Node<Id>>(node1));
+	m_nodes.insert_or_assign(node2, make_shared<Node<Id>>(node2));
   }
 
   template <typename Id, typename Size>

--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -85,9 +85,9 @@ namespace dsm {
     /// @param street, A reference to the street to add
     void addStreet(const Street<Id, Size>& street);
 
-    template <typename... Tn>
-      requires(is_street_v<Tn> && ...)
-    void addStreets(Tn&&... streets);
+    template <typename T1>
+      requires is_street_v<T1>
+    void addStreets(T1&& street);
 
     template <typename T1, typename... Tn>
       requires is_street_v<T1> && (is_street_v<Tn> && ...)
@@ -248,9 +248,17 @@ namespace dsm {
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  template <typename... Tn>
-    requires(is_street_v<Tn> && ...)
-  void Graph<Id, Size>::addStreets(Tn&&... edges) {}
+  template <typename T1>
+    requires is_street_v<T1>
+  void Graph<Id, Size>::addStreets(T1&& street) {
+	// insert street
+    m_streets.insert(std::make_pair(street.id(), make_shared<Street<Id, Size>>(street)));
+	// insert nodes
+	const Id node1{street.nodePair().first};
+	const Id node2{street.nodePair().second};
+	m_nodes.insert_or_assign(node1, make_shared<Node<Id>>(node1));
+	m_nodes.insert_or_assign(node2, make_shared<Node<Id>>(node2));
+  }
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)

--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -175,11 +175,12 @@ namespace dsm {
         bool val;
         file >> index >> val;
         m_adjacency->insert(index, val);
-		const Id node1{static_cast<Id>(index / rows)};
-		const Id node2{static_cast<Id>(index % cols)};
+        const Id node1{static_cast<Id>(index / rows)};
+        const Id node2{static_cast<Id>(index % cols)};
         m_nodes.insert_or_assign(node1, make_shared<Node<Id>>(node1));
         m_nodes.insert_or_assign(node2, make_shared<Node<Id>>(node2));
-        m_streets.insert_or_assign(index, make_shared<Street<Id, Size>>(index, std::make_pair(node1, node2)));
+        m_streets.insert_or_assign(index,
+                                   make_shared<Street<Id, Size>>(index, std::make_pair(node1, node2)));
       }
     } else {
       std::string errrorMsg = "Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
@@ -218,25 +219,25 @@ namespace dsm {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addStreet(shared<Street<Id, Size>> street) {
-	// insert street
+    // insert street
     m_streets.insert(std::make_pair(street->id(), street));
-	// insert nodes
-	const Id node1{street.nodePair().first};
-	const Id node2{street.nodePair().second};
-	m_nodes.insert_or_assign(node1);
-	m_nodes.insert_or_assign(node2);
+    // insert nodes
+    const Id node1{street.nodePair().first};
+    const Id node2{street.nodePair().second};
+    m_nodes.insert_or_assign(node1);
+    m_nodes.insert_or_assign(node2);
   }
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addStreet(const Street<Id, Size>& street) {
-	// insert street
+    // insert street
     m_streets.insert(std::make_pair(street.id(), make_shared<Street<Id, Size>>(street)));
-	// insert nodes
-	const Id node1{street.nodePair().first};
-	const Id node2{street.nodePair().second};
-	m_nodes.insert_or_assign(node1, make_shared<Node<Id>>(node1));
-	m_nodes.insert_or_assign(node2, make_shared<Node<Id>>(node2));
+    // insert nodes
+    const Id node1{street.nodePair().first};
+    const Id node2{street.nodePair().second};
+    m_nodes.insert_or_assign(node1, make_shared<Node<Id>>(node1));
+    m_nodes.insert_or_assign(node2, make_shared<Node<Id>>(node2));
   }
 
   template <typename Id, typename Size>
@@ -244,13 +245,13 @@ namespace dsm {
   template <typename T1>
     requires is_street_v<T1>
   void Graph<Id, Size>::addStreets(T1&& street) {
-	// insert street
+    // insert street
     m_streets.insert(std::make_pair(street.id(), make_shared<Street<Id, Size>>(street)));
-	// insert nodes
-	const Id node1{street.nodePair().first};
-	const Id node2{street.nodePair().second};
-	m_nodes.insert_or_assign(node1, make_shared<Node<Id>>(node1));
-	m_nodes.insert_or_assign(node2, make_shared<Node<Id>>(node2));
+    // insert nodes
+    const Id node1{street.nodePair().first};
+    const Id node2{street.nodePair().second};
+    m_nodes.insert_or_assign(node1, make_shared<Node<Id>>(node1));
+    m_nodes.insert_or_assign(node2, make_shared<Node<Id>>(node2));
   }
 
   template <typename Id, typename Size>

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -37,15 +37,11 @@ namespace dsm {
     Size m_capacity;
 
   public:
-    Street() = default;
+    Street() = delete;
     /// @brief Construct a new Street object
     /// @param index, The street's id
-    Street(Id index);
-    /// @brief Construct a new Street object
-    /// @param index, The street's id
-    /// @param capacity, The street's capacity
-    /// @param len, The street's length
-    Street(Id index, Size capacity, double len);
+    /// @param nodePair, The street's node pair
+    Street(Id index, std::pair<Id, Id> nodePair);
     /// @brief Construct a new Street object
     /// @param index, The street's id
     /// @param capacity, The street's capacity

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -118,7 +118,8 @@ namespace dsm {
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(Id index, std::pair<Id, Id> pair) : m_nodePair{std::move(pair)}, m_id{index}, m_size{0} {}
+  Street<Id, Size>::Street(Id index, std::pair<Id, Id> pair)
+      : m_nodePair{std::move(pair)}, m_id{index}, m_size{0} {}
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -118,12 +118,7 @@ namespace dsm {
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(Id index) : m_id{index}, m_size{0} {}
-
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(Id index, Size capacity, double len)
-      : m_len{len}, m_maxSpeed{30.}, m_id{index}, m_size{0}, m_capacity{capacity} {}
+  Street<Id, Size>::Street(Id index, std::pair<Id, Id> pair) : m_nodePair{std::move(pair)}, m_id{index}, m_size{0} {}
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -119,7 +119,7 @@ namespace dsm {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   Street<Id, Size>::Street(Id index, std::pair<Id, Id> pair)
-      : m_nodePair{std::move(pair)}, m_id{index}, m_size{0} {}
+      : m_nodePair{std::move(pair)}, m_maxSpeed{30.}, m_id{index}, m_size{0} {}
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)

--- a/test/Test_graph.cpp
+++ b/test/Test_graph.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Graph") {
     graph.addStreet(street);
     graph.buildAdj();
     CHECK(graph.streetSet().size() == 1);
-	CHECK_EQ(graph.nodeSet().size(), 2);
+    CHECK_EQ(graph.nodeSet().size(), 2);
     CHECK(graph.adjMatrix()->size() == 1);
   }
 
@@ -51,10 +51,10 @@ TEST_CASE("Graph") {
     graph.addStreet(s3);
     graph.addStreet(s4);
     graph.addStreet(s5);
-	graph.buildAdj();
+    graph.buildAdj();
 
-	CHECK_EQ(graph.streetSet().size(), 5);
-	CHECK_EQ(graph.nodeSet().size(), 4);
+    CHECK_EQ(graph.streetSet().size(), 5);
+    CHECK_EQ(graph.nodeSet().size(), 4);
     CHECK_EQ(graph.adjMatrix()->size(), 5);
     CHECK(graph.adjMatrix()->contains(0, 1));
     CHECK(graph.adjMatrix()->contains(1, 2));

--- a/test/Test_graph.cpp
+++ b/test/Test_graph.cpp
@@ -13,11 +13,12 @@ using Street = dsm::Street<uint16_t, uint16_t>;
 
 TEST_CASE("Graph") {
   SUBCASE("Constructor_1") {
-    Street street{1, 2, 3};
+    Street street{1, std::make_pair(0, 1)};
     Graph graph{};
     graph.addStreet(street);
     graph.buildAdj();
     CHECK(graph.streetSet().size() == 1);
+	CHECK_EQ(graph.nodeSet().size(), 2);
     CHECK(graph.adjMatrix()->size() == 1);
   }
 
@@ -36,6 +37,29 @@ TEST_CASE("Graph") {
     CHECK(graph.adjMatrix()->contains(2, 3));
     CHECK(graph.adjMatrix()->contains(3, 2));
     CHECK_FALSE(graph.adjMatrix()->contains(2, 1));
+  }
+
+  SUBCASE("Construction with addStreet") {
+    Street s1(1, std::make_pair(0, 1));
+    Street s2(2, std::make_pair(1, 2));
+    Street s3(3, std::make_pair(0, 2));
+    Street s4(4, std::make_pair(0, 3));
+    Street s5(5, std::make_pair(2, 3));
+    Graph graph;
+    graph.addStreet(s1);
+    graph.addStreet(s2);
+    graph.addStreet(s3);
+    graph.addStreet(s4);
+    graph.addStreet(s5);
+	graph.buildAdj();
+
+	CHECK_EQ(graph.streetSet().size(), 5);
+	CHECK_EQ(graph.nodeSet().size(), 4);
+    CHECK_EQ(graph.adjMatrix()->size(), 5);
+    CHECK(graph.adjMatrix()->contains(0, 1));
+    CHECK(graph.adjMatrix()->contains(1, 2));
+    CHECK(graph.adjMatrix()->contains(0, 2));
+    CHECK_FALSE(graph.adjMatrix()->contains(1, 3));
   }
 
   SUBCASE("importAdj - dsm") {

--- a/test/Test_street.cpp
+++ b/test/Test_street.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Street") {
     Agent a3{3, 1};
     Agent a4{4, 1};
 
-    Street street{1, std::make_pair(0, 1)};
+    Street street{1, 4, 3.5, std::make_pair(0, 1)};
     // fill the queue
     street.enqueue(a1);
     street.enqueue(a2);
@@ -121,7 +121,7 @@ TEST_CASE("Street") {
     Agent a3{3, 1};
     Agent a4{4, 1};
 
-    Street street{1, std::make_pair(0, 1)};
+    Street street{1, 4, 3.5, std::make_pair(0, 1)};
     // fill the queue
     street.enqueue(a1);
     street.enqueue(a2);

--- a/test/Test_street.cpp
+++ b/test/Test_street.cpp
@@ -20,12 +20,10 @@ TEST_CASE("Street") {
     THEN: The Id, capacity, and length are set correctly
     */
 
-    Street street{1, 2, 3.5};
+    Street street{1, std::make_pair(0, 1)};
     CHECK_EQ(street.id(), 1);
-    CHECK_EQ(street.capacity(), 2);
-    CHECK_EQ(street.length(), 3.5);
-    CHECK_EQ(street.nodePair(), std::pair<uint16_t, uint16_t>());
-    CHECK_EQ(street.density(), 0);
+    CHECK_EQ(street.nodePair().first, 0);
+    CHECK_EQ(street.nodePair().second, 1);
     CHECK_EQ(street.maxSpeed(), 30.);
   }
 
@@ -65,7 +63,7 @@ TEST_CASE("Street") {
   SUBCASE("SetNodePair_1") {
     /*This tests the setNodePair method*/
 
-    Street street{1, 2, 3.5};
+    Street street{1, std::make_pair(0, 1)};
     street.setNodePair(4, 5);
     CHECK_EQ(street.nodePair().first, 4);
     CHECK_EQ(street.nodePair().second, 5);
@@ -74,7 +72,7 @@ TEST_CASE("Street") {
   SUBCASE("SetNodePair_2") {
     /*This tests the setNodePair method*/
 
-    Street street{1, 2, 3.5};
+    Street street{1, std::make_pair(0, 1)};
     Node node1{4};
     Node node2{5};
     street.setNodePair(node1, node2);
@@ -85,7 +83,7 @@ TEST_CASE("Street") {
   SUBCASE("SetNodePair_3") {
     /*This tests the setNodePair method*/
 
-    Street street{1, 2, 3.5};
+    Street street{1, std::make_pair(0, 1)};
     street.setNodePair(std::make_pair(4, 5));
     CHECK_EQ(street.nodePair().first, 4);
     CHECK_EQ(street.nodePair().second, 5);
@@ -100,7 +98,7 @@ TEST_CASE("Street") {
     Agent a3{3, 1};
     Agent a4{4, 1};
 
-    Street street{1, 4, 3.5};
+    Street street{1, std::make_pair(0, 1)};
     // fill the queue
     street.enqueue(a1);
     street.enqueue(a2);
@@ -123,7 +121,7 @@ TEST_CASE("Street") {
     Agent a3{3, 1};
     Agent a4{4, 1};
 
-    Street street{1, 4, 3.5};
+    Street street{1, std::make_pair(0, 1)};
     // fill the queue
     street.enqueue(a1);
     street.enqueue(a2);


### PR DESCRIPTION
* This PR modifies the `addStreet` methods so that, in addition to inserting the street in the street map, they also insert its nodes in the node map (issue #64).
* In order to implement the previous node it became necessary to modify the constructors of the `Street` class so that they all require the pair of nodes (otherwise I could insert a street without nodes, and when trying to insert them in the node map this would cause problems)
* Some new checks have been added to the tests of the `Graph` class to make sure that the bug is now fixed