### PR TITLE
Update include paths in benchmark cmake files

### DIFF
--- a/benchmark/Graph/CMakeLists.txt
+++ b/benchmark/Graph/CMakeLists.txt
@@ -11,8 +11,8 @@ string(APPEND CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -g")
 # Set the folder for the executable
 set(EXECUTABLE_OUTPUT_PATH ../../)
 
-include_directories(../../src/)
-include_directories(../../src/utility/)
+include_directories(../../src/dsm/headers/)
+include_directories(../../src/dsm/utility/)
 
 # Compile
 add_executable(bench_graph.out BenchGraph.cpp)

--- a/benchmark/Street/CMakeLists.txt
+++ b/benchmark/Street/CMakeLists.txt
@@ -11,8 +11,8 @@ string(APPEND CMAKE_CXX_FLAGS "-Wall -Wextra -O3 -g")
 # Set the folder for the executable
 set(EXECUTABLE_OUTPUT_PATH ../../)
 
-include_directories(../../src/)
-include_directories(../../src/utility/)
+include_directories(../../src/dsm/headers)
+include_directories(../../src/dsm/utility/)
 
 # Compile
 add_executable(bench_street.out BenchStreet.cpp)


### PR DESCRIPTION
In the last reworks of the structure of the library we forgot to update the benchmarks as well. This PR fixes this.