### PR TITLE
Fix insertion of nodes with `addNode`

### DIFF
--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -198,13 +198,13 @@ namespace dsm {
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addNode(shared<Node<Id>> node) {
-    m_nodes.insert(node);
+    m_nodes.insert(std::make_pair(node->id(), node));
   }
 
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   void Graph<Id, Size>::addNode(const Node<Id>& node) {
-    m_nodes.insert(make_shared<Node<Id>>(node));
+    m_nodes.insert(std::make_pair(node.id(), make_shared<Node<Id>>(node)));
   }
 
   template <typename Id, typename Size>


### PR DESCRIPTION
When converting `Graph` members from sets to maps we forgot to update the insertion of nodes with the `addNode` methods. This PR fixes this.
This is also needed for PR #67, because it causes the compilation of benchmarks to fail.