### PR TITLE
Feature iteration over queues

### DIFF
--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -19,6 +19,7 @@
 #include "Agent.hpp"
 #include "Node.hpp"
 #include "../utility/TypeTraits/is_numeric.hpp"
+#include "../utility/queue.hpp"
 
 namespace dsm {
   /// @brief The Street class represents a street in the network.
@@ -28,7 +29,7 @@ namespace dsm {
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   class Street {
   private:
-    std::queue<Size> m_queue;
+    dsm::queue<Size> m_queue;
     std::pair<Id, Id> m_nodePair;
     double m_len;
     double m_maxSpeed;
@@ -68,7 +69,7 @@ namespace dsm {
     void setLength(double len);
     /// @brief Set the street's queue
     /// @param queue, The street's queue
-    void setQueue(std::queue<Size> queue);
+    void setQueue(dsm::queue<Size> queue);
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
@@ -98,8 +99,8 @@ namespace dsm {
     /// @return double, The street's length
     double length() const;
     /// @brief Get the street's queue
-    /// @return std::queue<Size>, The street's queue
-    const std::queue<Size>& queue() const;
+    /// @return dsm::queue<Size>, The street's queue
+    const dsm::queue<Size>& queue() const;
     /// @brief Get the street's node pair
     /// @return std::pair<Id, Id>, The street's node pair
     const std::pair<Id, Id>& nodePair() const;
@@ -162,7 +163,7 @@ namespace dsm {
   }
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::setQueue(std::queue<Size> queue) {
+  void Street<Id, Size>::setQueue(dsm::queue<Size> queue) {
     m_queue = std::move(queue);
   }
   template <typename Id, typename Size>
@@ -213,7 +214,7 @@ namespace dsm {
   }
   template <typename Id, typename Size>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  const std::queue<Size>& Street<Id, Size>::queue() const {
+  const dsm::queue<Size>& Street<Id, Size>::queue() const {
     return m_queue;
   }
   template <typename Id, typename Size>

--- a/src/dsm/utility/queue.hpp
+++ b/src/dsm/utility/queue.hpp
@@ -26,6 +26,7 @@ namespace dsm {
             typename Container = std::vector<T>,
             typename Compare = std::less<typename Container::value_type>>
   class priority_queue : public std::priority_queue<T, Container, Compare> {
+  public:
     typedef typename Container::iterator iterator;
     typedef typename Container::const_iterator const_iterator;
 

--- a/src/dsm/utility/queue.hpp
+++ b/src/dsm/utility/queue.hpp
@@ -40,4 +40,6 @@ namespace dsm {
     const T operator[](size_t i) const { return *(this->c.begin() + i); }
   };
 
+};  // namespace dsm
+
 #endif

--- a/src/dsm/utility/queue.hpp
+++ b/src/dsm/utility/queue.hpp
@@ -7,7 +7,7 @@
 namespace dsm {
   // use the default allocator for std::deque
   template <typename T, typename Container = std::deque<T>>
-  class queue {
+  class queue : public std::queue<T, Container> {
 	public:
 	  typedef typename Container::iterator iterator;
 	  typedef typename Container::const_iterator const_iterator;

--- a/src/dsm/utility/queue.hpp
+++ b/src/dsm/utility/queue.hpp
@@ -1,0 +1,26 @@
+
+#ifndef queue_hpp
+#define queue_hpp
+
+#include <queue>
+
+namespace dsm {
+  // use the default allocator for std::deque
+  template <typename T, typename Container = std::deque<T>>
+  class queue {
+	public:
+	  typedef typename Container::iterator iterator;
+	  typedef typename Container::const_iterator const_iterator;
+
+	  // c is a protected member of std::queue, which is the underlying container
+	  iterator begin() { return this->c.begin(); }
+	  iterator end() { return this->c.end(); }
+	  const_iterator begin() const { return this->c.begin(); }
+	  const_iterator end() const { return this->c.end(); }
+
+	  T operator[](size_t i) { return *(this->c.begin() + i); }
+	  const T operator[](size_t i) const { return *(this->c.begin() + i); }
+  };
+};
+
+#endif

--- a/src/dsm/utility/queue.hpp
+++ b/src/dsm/utility/queue.hpp
@@ -8,19 +8,35 @@ namespace dsm {
   // use the default allocator for std::deque
   template <typename T, typename Container = std::deque<T>>
   class queue : public std::queue<T, Container> {
-	public:
-	  typedef typename Container::iterator iterator;
-	  typedef typename Container::const_iterator const_iterator;
+  public:
+    typedef typename Container::iterator iterator;
+    typedef typename Container::const_iterator const_iterator;
 
-	  // c is a protected member of std::queue, which is the underlying container
-	  iterator begin() { return this->c.begin(); }
-	  iterator end() { return this->c.end(); }
-	  const_iterator begin() const { return this->c.begin(); }
-	  const_iterator end() const { return this->c.end(); }
+    // c is a protected member of std::queue, which is the underlying container
+    iterator begin() { return this->c.begin(); }
+    iterator end() { return this->c.end(); }
+    const_iterator begin() const { return this->c.begin(); }
+    const_iterator end() const { return this->c.end(); }
 
-	  T operator[](size_t i) { return *(this->c.begin() + i); }
-	  const T operator[](size_t i) const { return *(this->c.begin() + i); }
+    T operator[](size_t i) { return *(this->c.begin() + i); }
+    const T operator[](size_t i) const { return *(this->c.begin() + i); }
   };
-};
+
+  template <typename T,
+            typename Container = std::vector<T>,
+            typename Compare = std::less<typename Container::value_type>>
+  class priority_queue : public std::priority_queue<T, Container, Compare> {
+    typedef typename Container::iterator iterator;
+    typedef typename Container::const_iterator const_iterator;
+
+    // c is a protected member of std::queue, which is the underlying container
+    iterator begin() { return this->c.begin(); }
+    iterator end() { return this->c.end(); }
+    const_iterator begin() const { return this->c.begin(); }
+    const_iterator end() const { return this->c.end(); }
+
+    T operator[](size_t i) { return *(this->c.begin() + i); }
+    const T operator[](size_t i) const { return *(this->c.begin() + i); }
+  };
 
 #endif


### PR DESCRIPTION
This PR creates two types of queues, `dsm::queue` and `dsm::priority_queue`, which inherit from the stl implementation and add iterators and access operators. This is done because in the evolution of the system we need to be able to iterate over the elements of the queues (issue #101).

The iterators are defined through the iterators of the `Container` members of the two base classes, which are protected.

Note: I didn't update the queue member of the `Node` classes because we are reworking it in PR #96.