### PR TITLE
Add error on observable mean measurements

### DIFF
--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -34,10 +34,10 @@ namespace dsm {
   /// @param error The standard deviation of the sample
   template <typename T>
   struct Measurement {
-	T mean;
-	T error;
+    T mean;
+    T error;
 
-	Measurement(T mean, T error) : mean{mean}, error{error} {}
+    Measurement(T mean, T error) : mean{mean}, error{error} {}
   };
 
   /// @brief The Dynamics class represents the dynamics of the network.

--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -164,14 +164,14 @@ namespace dsm {
     /// @brief Compute the mean speed over nStreets randomly selected streets
     /// @param nStreets The number of streets to select
     /// @return std::pair<double, double> The mean speed of the streets and the standard deviation
-    std::pair<double, double> meanSpeed(Size nStreets) const;
+    std::pair<double, double> meanSpeed(Size nStreets) const;  // TODO: implement
     /// @brief Get the mean density of the streets
     /// @return std::pair<double, double> The mean density of the streets and the standard deviation
     std::pair<double, double> meanDensity() const;
     /// @brief Compute the mean density over nStreets randomly selected streets
     /// @param nStreets The number of streets to select
     /// @return std::pair<double, double> The mean density of the streets and the standard deviation
-    std::pair<double, double> meanDensity(Size nStreets) const;
+    std::pair<double, double> meanDensity(Size nStreets) const;  // TODO: implement
     /// @brief Get the mean flow of the streets
     /// @return std::pair<double, double> The mean flow of the streets and the standard deviation
     std::pair<double, double> meanFlow() const;
@@ -255,8 +255,8 @@ namespace dsm {
   }
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             is_numeric_v<Delay>
   void Dynamics<Id, Size, Delay>::updatePaths() {
     const Size dimension = m_graph->adjMatrix()->getRowDim();
     for (auto& itineraryPair : m_itineraries) {
@@ -445,8 +445,8 @@ namespace dsm {
   }
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             is_numeric_v<Delay>
   std::pair<double, double> Dynamics<Id, Size, Delay>::meanSpeed() const {
     if (m_agents.size() == 0) {
       return std::make_pair(0., 0.);
@@ -468,56 +468,55 @@ namespace dsm {
                     (m_agents.size() - 1)};
     return std::make_pair(mean, std::sqrt(variance));
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  std::pair<double, double> Dynamics<Id, Size, Delay>::meanSpeed(Size nStreets) const {
-    if (m_graph->streetSet().size() == 0) {
-      return std::make_pair(0., 0.);
-    }
-    std::vector<Id> streetIds;
-    streetIds.reserve(m_graph->streetSet().size());
-    for (auto const& street : m_graph->streetSet()) {
-      streetIds.push_back(street.first);
-    }
-    std::sample(streetIds.begin(),
-                streetIds.end(),
-                std::back_inserter(streetIds),
-                nStreets,
-                m_generator);
-    // find all agents on the selected streets
-    std::vector<std::reference_wrapper<const Agent<Id, Size, Delay>>> agents;
-    for (auto const& agent : m_agents) {
-      if (std::find(streetIds.begin(), streetIds.end(), agent.second->streetId()) !=
-          streetIds.end()) {
-        agents.push_back(std::cref(*agent.second));
-      }
-    }
-    if (agents.size() == 0) {
-      return std::make_pair(0., 0.);
-    }
-    double mean{std::accumulate(agents.cbegin(),
-                                agents.cend(),
-                                0.,
-                                [](double sum, const auto& agent) {
-                                  return sum + agent.get().speed();
-                                }) /
-                agents.size()};
-    double variance{std::accumulate(agents.cbegin(),
-                                    agents.cend(),
-                                    0.,
-                                    [mean](double sum, const auto& agent) {
-                                      return sum +
-                                             std::pow(agent.get().speed() - mean, 2);
-                                    }) /
-                    (agents.size() - 1)};
-    return std::make_pair(mean, std::sqrt(variance));
+  // template <typename Id, typename Size, typename Delay>
+  //   requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  //            is_numeric_v<Delay>
+  // std::pair<double, double> Dynamics<Id, Size, Delay>::meanSpeed(Size nStreets) const {
+  //   if (m_graph->streetSet().size() == 0) {
+  //     return std::make_pair(0., 0.);
+  //   }
+  //   std::vector<Id> streetIds;
+  //   streetIds.reserve(m_graph->streetSet().size());
+  //   for (auto const& street : m_graph->streetSet()) {
+  //     streetIds.push_back(street.first);
+  //   }
+  //   std::sample(streetIds.begin(),
+  //               streetIds.end(),
+  //               std::back_inserter(streetIds),
+  //               nStreets,
+  //               m_generator);
+  //   // find all agents on the selected streets
+  //   std::vector<std::reference_wrapper<const Agent<Id, Size, Delay>>> agents;
+  //   for (auto const& agent : m_agents) {
+  //     if (std::find(streetIds.begin(), streetIds.end(), agent.second->streetId()) !=
+  //         streetIds.end()) {
+  //       agents.push_back(std::cref(*agent.second));
+  //     }
+  //   }
+  //   if (agents.size() == 0) {
+  //     return std::make_pair(0., 0.);
+  //   }
+  //   double mean{std::accumulate(agents.cbegin(),
+  //                               agents.cend(),
+  //                               0.,
+  //                               [](double sum, const auto& agent) {
+  //                                 return sum + agent.get().speed();
+  //                               }) /
+  //               agents.size()};
+  //   double variance{std::accumulate(agents.cbegin(),
+  //                                   agents.cend(),
+  //                                   0.,
+  //                                   [mean](double sum, const auto& agent) {
+  //                                     return sum +
+  //                                            std::pow(agent.get().speed() - mean, 2);
+  //                                   }) /
+  //                   (agents.size() - 1)};
+  //   return std::make_pair(mean, std::sqrt(variance));
+  // }
 
-  }
-
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             is_numeric_v<Delay>
   std::pair<double, double> Dynamics<Id, Size, Delay>::meanDensity() const {
     if (m_graph->streetSet().size() == 0) {
       return std::make_pair(0., 0.);
@@ -541,8 +540,8 @@ namespace dsm {
   }
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             is_numeric_v<Delay>
   std::pair<double, double> Dynamics<Id, Size, Delay>::meanFlow() const {
     auto meanSpeed{this->meanSpeed()};
     auto meanDensity{this->meanDensity()};
@@ -558,8 +557,8 @@ namespace dsm {
   }
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             is_numeric_v<Delay>
   std::pair<double, double> Dynamics<Id, Size, Delay>::meanTravelTime() const {
     if (m_travelTimes.size() == 0) {
       return std::make_pair(0., 0.);
@@ -577,8 +576,8 @@ namespace dsm {
   }
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             std::unsigned_integral<Delay>
   class FirstOrderDynamics : public Dynamics<Id, Size, Delay> {
   private:
     std::vector<std::unique_ptr<Agent<Id, Size, Delay>>> m_agents;
@@ -598,14 +597,14 @@ namespace dsm {
   };
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             std::unsigned_integral<Delay>
   FirstOrderDynamics<Id, Size, Delay>::FirstOrderDynamics(const Graph<Id, Size>& graph)
       : Dynamics<Id, Size, Delay>(graph) {}
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             std::unsigned_integral<Delay>
   void FirstOrderDynamics<Id, Size, Delay>::setAgentSpeed(Size agentId) {
     auto agentIt{std::find_if(m_agents.begin(), m_agents.end(), [agentId](auto agent) {
       return agent->index() == agentId;
@@ -623,8 +622,8 @@ namespace dsm {
   }
 
   template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             std::unsigned_integral<Delay>
   void FirstOrderDynamics<Id, Size, Delay>::evolve(bool reinsert_agents) {
     for (auto& agent : m_agents) {
       if (!(agent->delay() > 0)) {

--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -28,6 +28,18 @@ namespace dsm {
 
   using TimePoint = long long unsigned int;
 
+  /// @brief The Measurement struct represents the mean of a quantity and its standard deviation
+  /// @tparam T The type of the mean and the standard deviation
+  /// @param mean The mean
+  /// @param error The standard deviation of the sample
+  template <typename T>
+  struct Measurement {
+	T mean;
+	T error;
+
+	Measurement(T mean, T error) : mean{mean}, error{error} {}
+  };
+
   /// @brief The Dynamics class represents the dynamics of the network.
   /// @tparam Id, The type of the graph's id. It must be an unsigned integral type.
   /// @tparam Size, The type of the graph's capacity. It must be an unsigned integral type.
@@ -159,29 +171,29 @@ namespace dsm {
     void evolve(F f, Tn... args);
 
     /// @brief Get the mean speed of the agents
-    /// @return std::pair<double, double> The mean speed of the agents and the standard deviation
-    std::pair<double, double> meanSpeed() const;
+    /// @return Measurement<double> The mean speed of the agents and the standard deviation
+    Measurement<double> meanSpeed() const;
     /// @brief Compute the mean speed over nStreets randomly selected streets
     /// @param nStreets The number of streets to select
-    /// @return std::pair<double, double> The mean speed of the streets and the standard deviation
-    std::pair<double, double> meanSpeed(Size nStreets) const;  // TODO: implement
+    /// @return Measurement<double> The mean speed of the streets and the standard deviation
+    Measurement<double> meanSpeed(Size nStreets) const;  // TODO: implement
     /// @brief Get the mean density of the streets
-    /// @return std::pair<double, double> The mean density of the streets and the standard deviation
-    std::pair<double, double> meanDensity() const;
+    /// @return Measurement<double> The mean density of the streets and the standard deviation
+    Measurement<double> meanDensity() const;
     /// @brief Compute the mean density over nStreets randomly selected streets
     /// @param nStreets The number of streets to select
-    /// @return std::pair<double, double> The mean density of the streets and the standard deviation
-    std::pair<double, double> meanDensity(Size nStreets) const;  // TODO: implement
+    /// @return Measurement<double> The mean density of the streets and the standard deviation
+    Measurement<double> meanDensity(Size nStreets) const;  // TODO: implement
     /// @brief Get the mean flow of the streets
-    /// @return std::pair<double, double> The mean flow of the streets and the standard deviation
-    std::pair<double, double> meanFlow() const;
+    /// @return Measurement<double> The mean flow of the streets and the standard deviation
+    Measurement<double> meanFlow() const;
     /// @brief Compute the mean flow over nStreets randomly selected streets
     /// @param nStreets The number of streets to select
-    /// @return std::pair<double, double> The mean flow of the streets and the standard deviation
-    std::pair<double, double> meanFlow(Size nStreets) const;
+    /// @return Measurement<double> The mean flow of the streets and the standard deviation
+    Measurement<double> meanFlow(Size nStreets) const;
     /// @brief Get the mean travel time of the agents
-    /// @return std::pair<double, double> The mean travel time of the agents and the standard
-    std::pair<double, double> meanTravelTime() const;
+    /// @return Measurement<double> The mean travel time of the agents and the standard
+    Measurement<double> meanTravelTime() const;
   };
 
   template <typename Id, typename Size, typename Delay>
@@ -447,9 +459,9 @@ namespace dsm {
   template <typename Id, typename Size, typename Delay>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
              is_numeric_v<Delay>
-  std::pair<double, double> Dynamics<Id, Size, Delay>::meanSpeed() const {
+  Measurement<double> Dynamics<Id, Size, Delay>::meanSpeed() const {
     if (m_agents.size() == 0) {
-      return std::make_pair(0., 0.);
+      return Measurement(0., 0.);
     }
     double mean{std::accumulate(m_agents.cbegin(),
                                 m_agents.cend(),
@@ -466,7 +478,7 @@ namespace dsm {
                                              std::pow(agent.second->speed() - mean, 2);
                                     }) /
                     (m_agents.size() - 1)};
-    return std::make_pair(mean, std::sqrt(variance));
+    return Measurement(mean, std::sqrt(variance));
   }
   // template <typename Id, typename Size, typename Delay>
   //   requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
@@ -517,9 +529,9 @@ namespace dsm {
   template <typename Id, typename Size, typename Delay>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
              is_numeric_v<Delay>
-  std::pair<double, double> Dynamics<Id, Size, Delay>::meanDensity() const {
+  Measurement<double> Dynamics<Id, Size, Delay>::meanDensity() const {
     if (m_graph->streetSet().size() == 0) {
-      return std::make_pair(0., 0.);
+      return Measurement(0., 0.);
     }
     double mean{std::accumulate(m_graph->streetSet().cbegin(),
                                 m_graph->streetSet().cend(),
@@ -536,13 +548,13 @@ namespace dsm {
                                              std::pow(street.second->density() - mean, 2);
                                     }) /
                     (m_graph->streetSet().size() - 1)};
-    return std::make_pair(mean, std::sqrt(variance));
+    return Measurement(mean, std::sqrt(variance));
   }
 
   template <typename Id, typename Size, typename Delay>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
              is_numeric_v<Delay>
-  std::pair<double, double> Dynamics<Id, Size, Delay>::meanFlow() const {
+  Measurement<double> Dynamics<Id, Size, Delay>::meanFlow() const {
     auto meanSpeed{this->meanSpeed()};
     auto meanDensity{this->meanDensity()};
 
@@ -553,13 +565,13 @@ namespace dsm {
     double variance{(meanSpeed.first * std::pow(meanDensity.second, 2) +
                      std::pow(meanSpeed.second, 2) * meanDensity.first) /
                     mean};
-    return std::make_pair(mean, std::sqrt(variance));
+    return Measurement(mean, std::sqrt(variance));
   }
 
   template <typename Id, typename Size, typename Delay>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
              is_numeric_v<Delay>
-  std::pair<double, double> Dynamics<Id, Size, Delay>::meanTravelTime() const {
+  Measurement<double> Dynamics<Id, Size, Delay>::meanTravelTime() const {
     if (m_travelTimes.size() == 0) {
       return std::make_pair(0., 0.);
     }
@@ -572,7 +584,7 @@ namespace dsm {
                                       return sum + std::pow(travelTime - mean, 2);
                                     }) /
                     (m_travelTimes.size() - 1)};
-    return std::make_pair(mean, std::sqrt(variance));
+    return Measurement(mean, std::sqrt(variance));
   }
 
   template <typename Id, typename Size, typename Delay>

--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -558,12 +558,12 @@ namespace dsm {
     auto meanSpeed{this->meanSpeed()};
     auto meanDensity{this->meanDensity()};
 
-    double mean{meanSpeed.first * meanDensity.first};
+    double mean{meanSpeed.mean * meanDensity.mean};
     if (mean == 0.) {
-      return std::make_pair(0., 0.);
+      return Measurement(0., 0.);
     }
-    double variance{(meanSpeed.first * std::pow(meanDensity.second, 2) +
-                     std::pow(meanSpeed.second, 2) * meanDensity.first) /
+    double variance{(meanSpeed.mean * std::pow(meanDensity.error, 2) +
+                     std::pow(meanSpeed.error, 2) * meanDensity.mean) /
                     mean};
     return Measurement(mean, std::sqrt(variance));
   }
@@ -573,7 +573,7 @@ namespace dsm {
              is_numeric_v<Delay>
   Measurement<double> Dynamics<Id, Size, Delay>::meanTravelTime() const {
     if (m_travelTimes.size() == 0) {
-      return std::make_pair(0., 0.);
+      return Measurement(0., 0.);
     }
     double mean{std::accumulate(m_travelTimes.cbegin(), m_travelTimes.cend(), 0.) /
                 m_travelTimes.size()};

--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -439,14 +439,13 @@ namespace dsm {
     if (m_agents.size() == 0) {
       return std::make_pair(0., 0.);
     }
-    double mean {
-      std::accumulate(
-          m_agents.cbegin(),
-          m_agents.cend(),
-          0.,
-          [](double sum, const auto& agent) { return sum + agent.second->speed(); }) /
-          m_agents.size();
-    }
+    double mean{std::accumulate(m_agents.cbegin(),
+                                m_agents.cend(),
+                                0.,
+                                [](double sum, const auto& agent) {
+                                  return sum + agent.second->speed();
+                                }) /
+                m_agents.size()};
     double variance{std::accumulate(m_agents.cbegin(),
                                     m_agents.cend(),
                                     0.,
@@ -465,14 +464,13 @@ namespace dsm {
     if (m_graph->streetSet().size() == 0) {
       return std::make_pair(0., 0.);
     }
-    double mean {
-      std::accumulate(
-          m_graph->streetSet().cbegin(),
-          m_graph->streetSet().cend(),
-          0.,
-          [](double sum, const auto& street) { return sum + street.second->density(); }) /
-          m_graph->streetSet().size();
-    }
+    double mean{std::accumulate(m_graph->streetSet().cbegin(),
+                                m_graph->streetSet().cend(),
+                                0.,
+                                [](double sum, const auto& street) {
+                                  return sum + street.second->density();
+                                }) /
+                m_graph->streetSet().size()};
     double variance{std::accumulate(m_graph->streetSet().cbegin(),
                                     m_graph->streetSet().cend(),
                                     0.,
@@ -492,6 +490,9 @@ namespace dsm {
     auto meanDensity{this->meanDensity()};
 
     double mean{meanSpeed.first * meanDensity.first};
+    if (mean == 0.) {
+      return std::make_pair(0., 0.);
+    }
     double variance{(meanSpeed.first * std::pow(meanDensity.second, 2) +
                      std::pow(meanSpeed.second, 2) * meanDensity.first) /
                     mean};

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -24,10 +24,14 @@ TEST_CASE("Dynamics") {
     Dynamics dynamics(graph);
     CHECK_EQ(dynamics.graph().nodeSet().size(), 3);
     CHECK_EQ(dynamics.graph().streetSet().size(), 4);
-    CHECK_EQ(dynamics.meanSpeed(), 0.);
-    CHECK_EQ(dynamics.meanDensity(), 0.);
-    CHECK_EQ(dynamics.meanFlow(), 0.);
-    CHECK_EQ(dynamics.meanTravelTime(), 0.);
+    CHECK_EQ(dynamics.meanSpeed().first, 0.);
+    CHECK_EQ(dynamics.meanSpeed().second, 0.);
+    CHECK_EQ(dynamics.meanDensity().first, 0.);
+    CHECK_EQ(dynamics.meanDensity().second, 0.);
+    CHECK_EQ(dynamics.meanFlow().first, 0.);
+    CHECK_EQ(dynamics.meanFlow().second, 0.);
+    CHECK_EQ(dynamics.meanTravelTime().first, 0.);
+    CHECK_EQ(dynamics.meanTravelTime().second, 0.);
   }
   SUBCASE("updatePaths") {
     /// GIVEN: a dynamics object

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -26,8 +26,12 @@ TEST_CASE("Dynamics") {
     CHECK_EQ(dynamics.graph().streetSet().size(), 4);
     CHECK_EQ(dynamics.meanSpeed().first, 0.);
     CHECK_EQ(dynamics.meanSpeed().second, 0.);
+    CHECK_EQ(dynamics.meanSpeed(2).first, 0.);
+    CHECK_EQ(dynamics.meanSpeed(2).second, 0.);
     CHECK_EQ(dynamics.meanDensity().first, 0.);
     CHECK_EQ(dynamics.meanDensity().second, 0.);
+    // CHECK_EQ(dynamics.meanDensity(3).first, 0.);
+    // CHECK_EQ(dynamics.meanDensity(3).second, 0.);
     CHECK_EQ(dynamics.meanFlow().first, 0.);
     CHECK_EQ(dynamics.meanFlow().second, 0.);
     CHECK_EQ(dynamics.meanTravelTime().first, 0.);

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -26,8 +26,8 @@ TEST_CASE("Dynamics") {
     CHECK_EQ(dynamics.graph().streetSet().size(), 4);
     CHECK_EQ(dynamics.meanSpeed().first, 0.);
     CHECK_EQ(dynamics.meanSpeed().second, 0.);
-    CHECK_EQ(dynamics.meanSpeed(2).first, 0.);
-    CHECK_EQ(dynamics.meanSpeed(2).second, 0.);
+    // CHECK_EQ(dynamics.meanSpeed(2).first, 0.);
+    // CHECK_EQ(dynamics.meanSpeed(2).second, 0.);
     CHECK_EQ(dynamics.meanDensity().first, 0.);
     CHECK_EQ(dynamics.meanDensity().second, 0.);
     // CHECK_EQ(dynamics.meanDensity(3).first, 0.);

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -24,18 +24,18 @@ TEST_CASE("Dynamics") {
     Dynamics dynamics(graph);
     CHECK_EQ(dynamics.graph().nodeSet().size(), 3);
     CHECK_EQ(dynamics.graph().streetSet().size(), 4);
-    CHECK_EQ(dynamics.meanSpeed().first, 0.);
-    CHECK_EQ(dynamics.meanSpeed().second, 0.);
+    CHECK_EQ(dynamics.meanSpeed().mean, 0.);
+    CHECK_EQ(dynamics.meanSpeed().error, 0.);
     // CHECK_EQ(dynamics.meanSpeed(2).first, 0.);
     // CHECK_EQ(dynamics.meanSpeed(2).second, 0.);
-    CHECK_EQ(dynamics.meanDensity().first, 0.);
-    CHECK_EQ(dynamics.meanDensity().second, 0.);
+    CHECK_EQ(dynamics.meanDensity().mean, 0.);
+    CHECK_EQ(dynamics.meanDensity().error, 0.);
     // CHECK_EQ(dynamics.meanDensity(3).first, 0.);
     // CHECK_EQ(dynamics.meanDensity(3).second, 0.);
-    CHECK_EQ(dynamics.meanFlow().first, 0.);
-    CHECK_EQ(dynamics.meanFlow().second, 0.);
-    CHECK_EQ(dynamics.meanTravelTime().first, 0.);
-    CHECK_EQ(dynamics.meanTravelTime().second, 0.);
+    CHECK_EQ(dynamics.meanFlow().mean, 0.);
+    CHECK_EQ(dynamics.meanFlow().error, 0.);
+    CHECK_EQ(dynamics.meanTravelTime().mean, 0.);
+    CHECK_EQ(dynamics.meanTravelTime().error, 0.);
   }
   SUBCASE("updatePaths") {
     /// GIVEN: a dynamics object


### PR DESCRIPTION
Rewrite `mean...()` functions to return an object of type `Measurement` containing mean and standard deviation.
Links #108
Closes #109