### PR TITLE
Add transportCapacity attributeto `Street` class

### DIFF
--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -127,22 +127,32 @@ namespace dsm {
   template <typename Id, typename Size>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   Street<Id, Size>::Street(Id index, std::pair<Id, Id> pair)
-      : m_nodePair{std::move(pair)}, m_maxSpeed{13.8888888889}, m_id{index}, m_capacity{1}, m_transportCapacity{std::numeric_limits<Size>::max()} {}
+      : m_nodePair{std::move(pair)},
+        m_len{1.},
+        m_maxSpeed{13.8888888889},
+        m_id{index},
+        m_capacity{1},
+        m_transportCapacity{std::numeric_limits<Size>::max()} {}
 
   template <typename Id, typename Size>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   Street<Id, Size>::Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair)
       : m_nodePair{std::move(nodePair)},
         m_len{len},
-        m_maxSpeed{30.},
+        m_maxSpeed{13.8888888889},
         m_id{id},
         m_capacity{capacity},
         m_transportCapacity{std::numeric_limits<Size>::max()} {}
 
   template <typename Id, typename Size>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
-  Street<Id, Size>::Street(Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
-      : m_nodePair{std::move(nodePair)}, m_len{len}, m_id{id}, m_capacity{capacity} {
+  Street<Id, Size>::Street(
+      Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
+      : m_nodePair{std::move(nodePair)},
+        m_len{len},
+        m_id{id},
+        m_capacity{capacity},
+        m_transportCapacity{std::numeric_limits<Size>::max()} {
     this->setMaxSpeed(maxSpeed);
   }
 
@@ -250,8 +260,8 @@ namespace dsm {
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::enqueue(Id agentId) {
     if (m_queue.size() == m_capacity) {
-      std::string errorMsg{"Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
-                           "The street's queue is full."};
+      std::string errorMsg{"Error at line " + std::to_string(__LINE__) + " in file " +
+                           __FILE__ + ": " + "The street's queue is full."};
       throw std::runtime_error(errorMsg);
     }
     m_queue.push(agentId);
@@ -259,7 +269,7 @@ namespace dsm {
   template <typename Id, typename Size>
     requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   std::optional<Id> Street<Id, Size>::dequeue() {
-    if(m_queue.empty()) {
+    if (m_queue.empty()) {
       return std::nullopt;
     }
     Id id = m_queue.front();

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -34,8 +34,8 @@ namespace dsm {
     double m_len;
     double m_maxSpeed;
     Id m_id;
-    Size m_size;
     Size m_capacity;
+    Size m_transportCapacity;
 
   public:
     Street() = delete;
@@ -63,6 +63,11 @@ namespace dsm {
     /// @brief Set the street's capacity
     /// @param capacity The street's capacity
     void setCapacity(Size capacity);
+    /// @brief Set the street's transport capacity
+    /// @details The transport capacity is the maximum number of agents that can traverse the street
+    ///          in a time step.
+    /// @param capacity The street's transport capacity
+    void setTransportCapacity(Size capacity);
     /// @brief Set the street's length
     /// @param len The street's length
     /// @throw std::invalid_argument, If the length is negative
@@ -89,12 +94,14 @@ namespace dsm {
     /// @brief Get the street's id
     /// @return Id, The street's id
     Id id() const;
-    /// @brief Get the street's size
-    /// @return Size, The street's size
-    Size size() const;
     /// @brief Get the street's capacity
     /// @return Size, The street's capacity
     Size capacity() const;
+    /// @brief Get the street's transport capacity
+    /// @details The transport capacity is the maximum number of agents that can traverse the street
+    ///          in a time step.
+    /// @return Size, The street's transport capacity
+    Size transportCapacity() const;
     /// @brief Get the street's length
     /// @return double, The street's length
     double length() const;
@@ -111,57 +118,51 @@ namespace dsm {
     /// @return double, The street's speed limit
     double maxSpeed() const;
     /// @brief Add an agent to the street's queue
-    /// @param agent, The agent to add
-    template <typename Delay>
-      requires is_numeric_v<Delay>
-    void enqueue(const Agent<Id, Size, Delay>& agent);
+    /// @param agentId The id of the agent to add to the street's queue
+    void enqueue(Id agentId);
     /// @brief Remove an agent from the street's queue
     std::optional<Id> dequeue();
   };
 
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   Street<Id, Size>::Street(Id index, std::pair<Id, Id> pair)
-      : m_nodePair{std::move(pair)},
-        m_maxSpeed{30.},
-        m_id{index},
-        m_size{0},
-        m_capacity{1} {}
+      : m_nodePair{std::move(pair)}, m_maxSpeed{13.8888888889}, m_id{index}, m_capacity{1}, m_transportCapacity{std::numeric_limits<Size>::max()} {}
 
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   Street<Id, Size>::Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair)
       : m_nodePair{std::move(nodePair)},
         m_len{len},
         m_maxSpeed{30.},
         m_id{id},
-        m_size{0},
-        m_capacity{capacity} {}
+        m_capacity{capacity},
+        m_transportCapacity{std::numeric_limits<Size>::max()} {}
 
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(
-      Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
-      : m_nodePair{std::move(nodePair)},
-        m_len{len},
-        m_id{id},
-        m_size{0},
-        m_capacity{capacity} {
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
+  Street<Id, Size>::Street(Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
+      : m_nodePair{std::move(nodePair)}, m_len{len}, m_id{id}, m_capacity{capacity} {
     this->setMaxSpeed(maxSpeed);
   }
 
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setId(Id id) {
     m_id = id;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setCapacity(Size capacity) {
     m_capacity = capacity;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
+  void Street<Id, Size>::setTransportCapacity(Size capacity) {
+    m_transportCapacity = capacity;
+  }
+  template <typename Id, typename Size>
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setLength(double len) {
     if (len < 0.) {
       std::string errorMsg{"Error at line " + std::to_string(__LINE__) + " in file " +
@@ -172,28 +173,28 @@ namespace dsm {
     m_len = len;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setQueue(dsm::queue<Size> queue) {
     m_queue = std::move(queue);
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setNodePair(Id node1, Id node2) {
     m_nodePair = std::make_pair(node1, node2);
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setNodePair(const Node<Id, Size>& node1,
                                      const Node<Id, Size>& node2) {
     m_nodePair = std::make_pair(node1.id(), node2.id());
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setNodePair(std::pair<Id, Id> pair) {
     m_nodePair = std::move(pair);
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   void Street<Id, Size>::setMaxSpeed(double speed) {
     if (speed < 0.) {
       std::string errorMsg{"Error at line " + std::to_string(__LINE__) + " in file " +
@@ -205,69 +206,65 @@ namespace dsm {
   }
 
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   Id Street<Id, Size>::id() const {
     return m_id;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Size Street<Id, Size>::size() const {
-    return m_size;
-  }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   Size Street<Id, Size>::capacity() const {
     return m_capacity;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
+  Size Street<Id, Size>::transportCapacity() const {
+    return m_transportCapacity;
+  }
+  template <typename Id, typename Size>
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   double Street<Id, Size>::length() const {
     return m_len;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   const dsm::queue<Size>& Street<Id, Size>::queue() const {
     return m_queue;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   const std::pair<Id, Id>& Street<Id, Size>::nodePair() const {
     return m_nodePair;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   double Street<Id, Size>::density() const {
-    return static_cast<double>(m_size) / m_capacity;
+    return static_cast<double>(m_queue.size()) / m_capacity;
   }
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   double Street<Id, Size>::maxSpeed() const {
     return m_maxSpeed;
   }
 
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  template <typename Delay>
-    requires is_numeric_v<Delay>
-  void Street<Id, Size>::enqueue(const Agent<Id, Size, Delay>& agent) {
-    if (m_size < m_capacity) {
-      m_queue.push(agent.id());
-      ++m_size;
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
+  void Street<Id, Size>::enqueue(Id agentId) {
+    if (m_queue.size() == m_capacity) {
+      std::string errorMsg{"Error at line " + std::to_string(__LINE__) + " in file " + __FILE__ + ": " +
+                           "The street's queue is full."};
+      throw std::runtime_error(errorMsg);
     }
+    m_queue.push(agentId);
   }
-
   template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
+    requires std::unsigned_integral<Id> && std::unsigned_integral<Size>
   std::optional<Id> Street<Id, Size>::dequeue() {
-    if (m_size > 0) {
-      Id res{m_queue.front()};
-      m_queue.pop();
-      --m_size;
-
-      return res;
+    if(m_queue.empty()) {
+      return std::nullopt;
     }
-
-    return std::nullopt;
+    Id id = m_queue.front();
+    m_queue.pop();
+    return id;
   }
 
 };  // namespace dsm

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -44,12 +44,15 @@ namespace dsm {
     /// @param nodePair The street's node pair
     Street(Id id, std::pair<Id, Id> nodePair);
     /// @brief Construct a new Street object
+    /// @details The default capacity is 1, the default length is 1, and the default speed limit is
+    ///          50 km/h, i.e. 13.8888888889 m/s.
     /// @param id The street's id
     /// @param capacity The street's capacity
-    /// @param len, The street's length
-    /// @param nodePair, The street's node pair
+    /// @param len The street's length
+    /// @param nodePair The street's node pair
     Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
     /// @brief Construct a new Street object
+    /// @details The default speed limit is 50 km/h, i.e. 13.8888888889 m/s.
     /// @param id The street's id
     /// @param capacity The street's capacity
     /// @param len The street's length
@@ -73,7 +76,7 @@ namespace dsm {
     /// @throw std::invalid_argument, If the length is negative
     void setLength(double len);
     /// @brief Set the street's queue
-    /// @param queue, The street's queue
+    /// @param queue The street's queue
     void setQueue(dsm::queue<Size> queue);
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street

--- a/test/Test_street.cpp
+++ b/test/Test_street.cpp
@@ -22,9 +22,12 @@ TEST_CASE("Street") {
 
     Street street{1, std::make_pair(0, 1)};
     CHECK_EQ(street.id(), 1);
+    CHECK_EQ(street.capacity(), 1);
+    CHECK_EQ(street.transportCapacity(), 65535);
+    CHECK_EQ(street.length(), 1.);
     CHECK_EQ(street.nodePair().first, 0);
     CHECK_EQ(street.nodePair().second, 1);
-    CHECK_EQ(street.maxSpeed(), 30.);
+    CHECK_EQ(street.maxSpeed(), 13.8888888889);
   }
 
   SUBCASE("Constructor_2") {
@@ -37,11 +40,12 @@ TEST_CASE("Street") {
     Street street{1, 2, 3.5, std::make_pair(4, 5)};
     CHECK_EQ(street.id(), 1);
     CHECK_EQ(street.capacity(), 2);
+    CHECK_EQ(street.transportCapacity(), 65535);
     CHECK_EQ(street.length(), 3.5);
     CHECK_EQ(street.nodePair().first, 4);
     CHECK_EQ(street.nodePair().second, 5);
     CHECK_EQ(street.density(), 0);
-    CHECK_EQ(street.maxSpeed(), 30.);
+    CHECK_EQ(street.maxSpeed(), 13.8888888889);
   }
   SUBCASE("Constructor_3") {
     /*This tests the constructor that takes an Id, capacity, length, nodePair, and maxSpeed.
@@ -53,6 +57,7 @@ TEST_CASE("Street") {
     Street street{1, 2, 3.5, 40., std::make_pair(4, 5)};
     CHECK_EQ(street.id(), 1);
     CHECK_EQ(street.capacity(), 2);
+    CHECK_EQ(street.transportCapacity(), 65535);
     CHECK_EQ(street.length(), 3.5);
     CHECK_EQ(street.nodePair().first, 4);
     CHECK_EQ(street.nodePair().second, 5);
@@ -100,15 +105,15 @@ TEST_CASE("Street") {
 
     Street street{1, 4, 3.5, std::make_pair(0, 1)};
     // fill the queue
-    street.enqueue(a1);
-    street.enqueue(a2);
+    street.enqueue(a1.id());
+    street.enqueue(a2.id());
     CHECK_EQ(street.density(), 0.5);
-    street.enqueue(a3);
-    street.enqueue(a4);
+    street.enqueue(a3.id());
+    street.enqueue(a4.id());
     CHECK_EQ(street.queue().front(), 1);
     CHECK_EQ(street.queue().back(), 4);
     CHECK_EQ(street.queue().size(), street.capacity());
-    CHECK_EQ(street.size(), street.capacity());
+    CHECK_EQ(street.queue().size(), street.capacity());
     CHECK_EQ(street.density(), 1);
   }
 
@@ -123,22 +128,21 @@ TEST_CASE("Street") {
 
     Street street{1, 4, 3.5, std::make_pair(0, 1)};
     // fill the queue
-    street.enqueue(a1);
-    street.enqueue(a2);
-    street.enqueue(a3);
-    street.enqueue(a4);
-    CHECK_EQ(street.queue().front(),
-             1);  // check that agent 1 is at the front of the queue
+    street.enqueue(a1.id());
+    street.enqueue(a2.id());
+    street.enqueue(a3.id());
+    street.enqueue(a4.id());
+    CHECK_EQ(street.queue().front(), 1);  // check that agent 1 is at the front of the queue
 
     // dequeue
     street.dequeue();
     CHECK_EQ(street.queue().front(), 2);  // check that agent 2 is now at front
     // check that the length of the queue has decreased
     CHECK_EQ(street.queue().size(), 3);
-    CHECK_EQ(street.size(), 3);
+    CHECK_EQ(street.queue().size(), 3);
     // check that the next agent dequeued is agent 2
     CHECK_EQ(street.dequeue().value(), 2);
-    CHECK_EQ(street.size(), 2);
+    CHECK_EQ(street.queue().size(), 2);
     street.dequeue();
     street.dequeue();  // the queue is now empty
     // check that the result of dequeue is std::nullopt


### PR DESCRIPTION
In Street class and tests:
- add `m_transportCapacity` attribute
- remove `m_size` attribute
- fix Docygen comments
- rework `enqueue()` and `dequeue()` methods in order to remove the dependence from the Agent class
- refactor tests