### PR TITLE
Dynamic `setDelay` function in nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.0)
 
-project(dms VERSION 1.1.0 LANGUAGES CXX)
+project(dms VERSION 1.1.1 LANGUAGES CXX)
 
 # set the C++ standard
 set(CMAKE_CXX_STANDARD 20)

--- a/src/dsm/headers/Node.hpp
+++ b/src/dsm/headers/Node.hpp
@@ -313,7 +313,7 @@ namespace dsm {
   void TrafficLight<Id, Size, Delay>::setDelay(Delay delay) {
     if (m_delay.has_value()) {
       if (m_counter >= delay + m_delay.value().second) {
-          m_counter = delay + m_delay.value().second - 1;
+        m_counter = delay + m_delay.value().second - 1;
       } else if (delay < m_delay.value().first) {
         if (m_counter >= delay && m_counter <= m_delay.value().first) {
           m_counter = delay - (m_delay.value().first - m_counter);
@@ -326,11 +326,11 @@ namespace dsm {
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
              std::unsigned_integral<Delay>)
   void TrafficLight<Id, Size, Delay>::setDelay(std::pair<Delay, Delay> delay) {
-    if(m_delay.has_value()) {
-      if(m_counter >= delay.first + delay.second) {
+    if (m_delay.has_value()) {
+      if (m_counter >= delay.first + delay.second) {
         m_counter = delay.first + delay.second - 1;
-      } else if(delay.first < m_delay.value().first) {
-        if(m_counter >= delay.first && m_counter <= m_delay.value().first) {
+      } else if (delay.first < m_delay.value().first) {
+        if (m_counter >= delay.first && m_counter <= m_delay.value().first) {
           m_counter = delay.first - (m_delay.value().first - m_counter);
         }
       }

--- a/src/dsm/headers/Node.hpp
+++ b/src/dsm/headers/Node.hpp
@@ -256,13 +256,17 @@ namespace dsm {
   private:
     std::optional<std::pair<Delay, Delay>> m_delay;
     Delay m_counter;
+    Delay m_yellowDelay{5};
 
   public:
-    TrafficLight() = default;
+    TrafficLight() = delete;
     /// @brief Construct a new TrafficLight object
     /// @param id The node's id
-    TrafficLight(Id id);
+    explicit TrafficLight(Id id);
 
+    /// @brief Set the node's yellow delay
+    /// @param delay The node's yellow delay
+    void setYellowDelay(Delay delay);
     /// @brief Set the node's delay
     /// @param delay The node's delay
     void setDelay(Delay delay);
@@ -293,8 +297,14 @@ namespace dsm {
   template <typename Id, typename Size, typename Delay>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
              std::unsigned_integral<Delay>)
-  TrafficLight<Id, Size, Delay>::TrafficLight(Id id) : Node<Id, Size>{id}, m_counter{0} {}
+  TrafficLight<Id, Size, Delay>::TrafficLight(Id id) : Node<Id, Size>{id}, m_counter{0}, m_yellowDelay{5} {}
 
+  template <typename Id, typename Size, typename Delay>
+    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+             std::unsigned_integral<Delay>)
+  void TrafficLight<Id, Size, Delay>::setYellowDelay(Delay delay) {
+    m_yellowDelay = delay;
+  }
   template <typename Id, typename Size, typename Delay>
     requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
              std::unsigned_integral<Delay>)

--- a/test/Test_node.cpp
+++ b/test/Test_node.cpp
@@ -107,4 +107,36 @@ TEST_CASE("TrafficLight") {
     }
     CHECK(trafficLight.isGreen());
   }
+  SUBCASE("Dynamic traffic light") {
+    GIVEN("A traffic ligth object with set delay") {
+      TrafficLight tl{0};
+      tl.setDelay(std::make_pair(5, 3));
+      WHEN("The delay is set with a green value smaller than the previous one") {
+        tl.increaseCounter();
+        tl.increaseCounter();
+        tl.increaseCounter();
+        tl.setDelay(std::make_pair(2, 3));
+        THEN("It is green for two cycles") {
+          CHECK(tl.isGreen());
+          tl.increaseCounter();
+          CHECK(tl.isGreen());
+          tl.increaseCounter();
+          CHECK_FALSE(tl.isGreen());
+        }
+      }
+      WHEN("The delay is set with a red value smaller than the previous one") {
+        tl.increaseCounter();
+        tl.increaseCounter();
+        tl.increaseCounter();
+        tl.increaseCounter();
+        tl.increaseCounter();
+        tl.setDelay(std::make_pair(1, 3));
+        THEN("It is red for one cycles") {
+          CHECK_FALSE(tl.isGreen());
+          tl.increaseCounter();
+          CHECK(tl.isGreen());
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
In this PR:
- Improve `setDelay` function for traffic light nodes: now it can change dynamically during the evolution.
- Fix #140