### PR TITLE
Create dockerfile for testing and developing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+
+*.git*
+*.github
+LICENSE
+*.out
+*build

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@
 *.github
 LICENSE
 *.out
-*build
+**build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 
 FROM almalinux:9
 
-COPY ./ /app
+# copy the source in a directory for testing
+COPY ./ /app/test/
+# create an empty directory for development where
+# the host directory will have to be mounted
+RUN mkdir /app/develop/
 
+# install the necessary packages
 RUN dnf install -y gcc-c++ \
 				   clang-tools-extra \
 				   make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN dnf install -y gcc-c++ \
 				   clang-tools-extra \
 				   make \
 				   cmake \
+				   gdb \
+				   valgrind \
 				   python3-pip \
 				   vim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN dnf install -y gcc-c++ \
 				   cmake \
 				   gdb \
 				   valgrind \
+				   git \
 				   python3-pip \
 				   vim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+
+FROM almalinux:8
+
+COPY ./ /app
+
+RUN dnf install -y gcc-c++ \
+				   clang-tools-extra \
+				   make \
+				   cmake \
+				   python3-pip \
+				   vim
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM almalinux:8
+FROM almalinux:9
 
 COPY ./ /app
 


### PR DESCRIPTION
This PR creates a dockerfile which allows to test, benchmark and profile the library in a docker container based on `almalinux 9`.

In the `/app` folder inside the container there is a folder `test` where the content of the project is copied for testing purposes, and another folder named `develop` which is empty and is where the host folder should be mounter for developing inside the container.