### PR TITLE
Reduce the use of templates for indexes

### DIFF
--- a/benchmark/Dynamics/BenchDynamics.cpp
+++ b/benchmark/Dynamics/BenchDynamics.cpp
@@ -5,9 +5,9 @@
 #include "Dynamics.hpp"
 #include "Bench.hpp"
 
-using Graph = dsm::Graph<uint32_t, uint32_t>;
-using Itinerary = dsm::Itinerary<uint32_t>;
-using Dynamics = dsm::FirstOrderDynamics<uint32_t, uint32_t, uint32_t>;
+using Graph = dsm::Graph;
+using Itinerary = dsm::Itinerary;
+using Dynamics = dsm::FirstOrderDynamics<uint32_t>;
 
 using Bench = sb::Bench<long long int>;
 

--- a/benchmark/Dynamics/CMakeLists.txt
+++ b/benchmark/Dynamics/CMakeLists.txt
@@ -14,5 +14,7 @@ set(EXECUTABLE_OUTPUT_PATH ../../)
 include_directories(../../src/dsm/headers)
 include_directories(../../src/dsm/utility/)
 
+file(GLOB SOURCES "../../src/dsm/headers/*.cpp")
+
 # Compile
-add_executable(bench_dynamics.out BenchDynamics.cpp)
+add_executable(bench_dynamics.out BenchDynamics.cpp ${SOURCES})

--- a/benchmark/Graph/BenchGraph.cpp
+++ b/benchmark/Graph/BenchGraph.cpp
@@ -7,10 +7,10 @@
 
 #include "Graph.hpp"
 
-using Graph = dsm::Graph<uint32_t, uint32_t>;
-using Intersection = dsm::Intersection<uint32_t, uint32_t>;
-using Street = dsm::Street<uint32_t, uint32_t>;
-using SparseMatrix = dsm::SparseMatrix<uint32_t, bool>;
+using Graph = dsm::Graph;
+using Intersection = dsm::Intersection;
+using Street = dsm::Street;
+using SparseMatrix = dsm::SparseMatrix<bool>;
 
 using Bench = sb::Bench<long long int>;
 

--- a/benchmark/Graph/CMakeLists.txt
+++ b/benchmark/Graph/CMakeLists.txt
@@ -14,5 +14,7 @@ set(EXECUTABLE_OUTPUT_PATH ../../)
 include_directories(../../src/dsm/headers/)
 include_directories(../../src/dsm/utility/)
 
+file(GLOB SOURCES "../../src/dsm/headers/*.cpp")
+
 # Compile
-add_executable(bench_graph.out BenchGraph.cpp)
+add_executable(bench_graph.out BenchGraph.cpp ${SOURCES})

--- a/benchmark/Street/BenchStreet.cpp
+++ b/benchmark/Street/BenchStreet.cpp
@@ -6,9 +6,9 @@
 
 #include "Graph.hpp"
 
-using Agent = dsm::Agent<uint32_t, uint32_t, double>;
-using Street = dsm::Street<uint32_t, uint32_t>;
-using SparseMatrix = dsm::SparseMatrix<uint32_t, bool>;
+using Agent = dsm::Agent<double>;
+using Street = dsm::Street;
+using SparseMatrix = dsm::SparseMatrix<bool>;
 
 using Bench = sb::Bench<long long int>;
 

--- a/benchmark/Street/CMakeLists.txt
+++ b/benchmark/Street/CMakeLists.txt
@@ -14,5 +14,7 @@ set(EXECUTABLE_OUTPUT_PATH ../../)
 include_directories(../../src/dsm/headers)
 include_directories(../../src/dsm/utility/)
 
+file(GLOB SOURCES "../../src/dsm/headers/*.cpp")
+
 # Compile
-add_executable(bench_street.out BenchStreet.cpp)
+add_executable(bench_street.out BenchStreet.cpp ${SOURCES})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,10 +19,11 @@ set(EXECUTABLE_OUTPUT_PATH ../)
 
 # add as executable all cpp files into '.' folder
 file(GLOB SOURCES "*.cpp")
+file(GLOB SRC_SOURCES "../src/dsm/headers/*.cpp")
 
 # Loop through each source file and create an executable
 foreach(SOURCE ${SOURCES})
     get_filename_component(EXE_NAME ${SOURCE} NAME_WE)
-    add_executable(${EXE_NAME}.out ${SOURCE})
+	add_executable(${EXE_NAME}.out ${SOURCE} ${SRC_SOURCES})
     target_include_directories(${EXE_NAME}.out PRIVATE ../src/dsm/headers/ ../src/dsm/utility/TypeTraits/)
 endforeach()

--- a/examples/slow_charge_rb.cpp
+++ b/examples/slow_charge_rb.cpp
@@ -29,11 +29,11 @@ uint nAgents{450};
 using Unit = unsigned int;
 using Delay = uint8_t;
 
-using Graph = dsm::Graph<Unit, Unit>;
-using Dynamics = dsm::FirstOrderDynamics<Unit, Unit, Delay>;
-using Street = dsm::Street<Unit, Unit>;
-using SpireStreet = dsm::SpireStreet<Unit, Unit>;
-using Roundabout = dsm::Roundabout<Unit, Unit>;
+using Graph = dsm::Graph;
+using Dynamics = dsm::FirstOrderDynamics<Delay>;
+using Street = dsm::Street;
+using SpireStreet = dsm::SpireStreet;
+using Roundabout = dsm::Roundabout;
 
 void printLoadingBar(int const i, int const n) {
   std::cout << "Loading: " << std::setprecision(2) << std::fixed << (i * 100. / n) << "%"

--- a/examples/slow_charge_tl.cpp
+++ b/examples/slow_charge_tl.cpp
@@ -30,11 +30,11 @@ uint nAgents{315};  // 315 for error probability 0.3, 450 for error probability 
 using Unit = unsigned int;
 using Delay = uint8_t;
 
-using Graph = dsm::Graph<Unit, Unit>;
-using Dynamics = dsm::FirstOrderDynamics<Unit, Unit, Delay>;
-using Street = dsm::Street<Unit, Unit>;
-using SpireStreet = dsm::SpireStreet<Unit, Unit>;
-using TrafficLight = dsm::TrafficLight<Unit, Unit, Delay>;
+using Graph = dsm::Graph;
+using Dynamics = dsm::FirstOrderDynamics<Delay>;
+using Street = dsm::Street;
+using SpireStreet = dsm::SpireStreet;
+using TrafficLight = dsm::TrafficLight<Delay>;
 
 void printLoadingBar(int const i, int const n) {
   std::cout << "Loading: " << std::setprecision(2) << std::fixed << (i * 100. / n) << "%"

--- a/examples/stalingrado.cpp
+++ b/examples/stalingrado.cpp
@@ -19,12 +19,12 @@ std::atomic<unsigned int> progress{0};
 using Unit = unsigned int;
 using Delay = uint8_t;
 
-using Graph = dsm::Graph<Unit, Unit>;
-using Itinerary = dsm::Itinerary<Unit>;
-using Dynamics = dsm::FirstOrderDynamics<Unit, Unit, Delay>;
-using Street = dsm::Street<Unit, Unit>;
-using SpireStreet = dsm::SpireStreet<Unit, Unit>;
-using TrafficLight = dsm::TrafficLight<Unit, Unit, Delay>;
+using Graph = dsm::Graph;
+using Itinerary = dsm::Itinerary;
+using Dynamics = dsm::FirstOrderDynamics<Delay>;
+using Street = dsm::Street;
+using SpireStreet = dsm::SpireStreet;
+using TrafficLight = dsm::TrafficLight<Delay>;
 
 void printLoadingBar(int const i, int const n) {
   std::cout << "Loading: " << std::setprecision(2) << std::fixed << (i * 100. / n) << "%"

--- a/profiling/CMakeLists.txt
+++ b/profiling/CMakeLists.txt
@@ -13,11 +13,13 @@ string(APPEND CMAKE_CXX_FLAGS "-Wall -Wextra -Os")
 # Set the folder for the executable
 set(EXECUTABLE_OUTPUT_PATH ../)
 
+file(GLOB SOURCES "../src/dsm/headers/*.cpp")
+
 # Define the executable
-add_executable(prof.out main.cpp)
+add_executable(prof.out main.cpp ${SOURCES})
 target_include_directories(prof.out PRIVATE ../src/)
 target_compile_options(prof.out PRIVATE -pg)
 target_link_options(prof.out PRIVATE -pg)
-add_executable(mem.out main.cpp)
+add_executable(mem.out main.cpp ${SOURCES})
 target_include_directories(mem.out PRIVATE ../src/)
 add_executable(parse_massif.out parse_massif.cpp)

--- a/profiling/main.cpp
+++ b/profiling/main.cpp
@@ -8,9 +8,9 @@
 
 using unit = uint32_t;
 
-using Graph = dsm::Graph<unit, unit>;
-using Itinerary = dsm::Itinerary<unit>;
-using Dynamics = dsm::FirstOrderDynamics<unit, unit, unit>;
+using Graph = dsm::Graph;
+using Itinerary = dsm::Itinerary;
+using Dynamics = dsm::FirstOrderDynamics<unit>;
 
 int main() {
   Graph graph{};

--- a/src/dsm/dsm.hpp
+++ b/src/dsm/dsm.hpp
@@ -5,7 +5,7 @@
 #include <format>
 
 static constexpr uint8_t DSM_VERSION_MAJOR = 1;
-static constexpr uint8_t DSM_VERSION_MINOR = 5;
+static constexpr uint8_t DSM_VERSION_MINOR = 6;
 static constexpr uint8_t DSM_VERSION_PATCH = 0;
 
 namespace dsm {

--- a/src/dsm/dsm.hpp
+++ b/src/dsm/dsm.hpp
@@ -4,8 +4,8 @@
 #include <cstdint>
 #include <format>
 
-static constexpr uint8_t DSM_VERSION_MAJOR = 1;
-static constexpr uint8_t DSM_VERSION_MINOR = 6;
+static constexpr uint8_t DSM_VERSION_MAJOR = 2;
+static constexpr uint8_t DSM_VERSION_MINOR = 0;
 static constexpr uint8_t DSM_VERSION_PATCH = 0;
 
 namespace dsm {

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -14,6 +14,7 @@
 #include "SparseMatrix.hpp"
 #include "../utility/TypeTraits/is_numeric.hpp"
 #include "../utility/Logger.hpp"
+#include "../utility/Typedef.hpp"
 
 #include <concepts>
 #include <stdexcept>
@@ -25,9 +26,8 @@ namespace dsm {
   /// @tparam Id, The type of the agent's id. It must be an unsigned integral type.
   /// @tparam Size, The type of the size of a street. It must be an unsigned integral type.
   /// @tparam Delay, The type of the agent's delay. It must be a numeric type (see utility/TypeTraits/is_numeric.hpp).
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   class Agent {
   private:
     Id m_id;
@@ -114,10 +114,9 @@ namespace dsm {
     unsigned int time() const { return m_time; }
   };
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Agent<Id, Size, Delay>::Agent(Id id, Id itineraryId)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Agent<Delay>::Agent(Id id, Id itineraryId)
       : m_id{id},
         m_itineraryId{itineraryId},
         m_delay{0},
@@ -125,10 +124,9 @@ namespace dsm {
         m_distance{0.},
         m_time{0} {}
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Agent<Id, Size, Delay>::Agent(Id id, Id itineraryId, Id srcNodeId)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Agent<Delay>::Agent(Id id, Id itineraryId, Id srcNodeId)
       : m_id{id},
         m_itineraryId{itineraryId},
         m_srcNodeId{srcNodeId},
@@ -137,66 +135,59 @@ namespace dsm {
         m_distance{0.},
         m_time{0} {}
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Agent<Id, Size, Delay>::setSpeed(double speed) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Agent<Delay>::setSpeed(double speed) {
     if (speed < 0) {
       throw std::invalid_argument(buildLog("Speed must be positive"));
     }
     m_speed = speed;
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Agent<Id, Size, Delay>::incrementDelay() {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Agent<Delay>::incrementDelay() {
     if (m_delay == std::numeric_limits<Delay>::max()) {
       throw std::overflow_error(buildLog("Delay has reached its maximum value"));
     }
     ++m_delay;
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Agent<Id, Size, Delay>::incrementDelay(Delay delay) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Agent<Delay>::incrementDelay(Delay delay) {
     if (m_delay + delay < m_delay) {
       throw std::overflow_error(buildLog("Delay has reached its maximum value"));
     }
     m_delay = delay;
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Agent<Id, Size, Delay>::decrementDelay() {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Agent<Delay>::decrementDelay() {
     if (m_delay == 0) {
       throw std::underflow_error(buildLog("Delay has reached its minimum value"));
     }
     --m_delay;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Agent<Id, Size, Delay>::incrementDistance(double distance) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Agent<Delay>::incrementDistance(double distance) {
     if (distance < 0) {
       throw std::invalid_argument(buildLog("Distance travelled must be positive"));
     }
     m_distance += distance;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Agent<Id, Size, Delay>::incrementTime() {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Agent<Delay>::incrementTime() {
     if (m_time == std::numeric_limits<unsigned int>::max()) {
       throw std::overflow_error(buildLog("Time has reached its maximum value"));
     }
     ++m_time;
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Agent<Id, Size, Delay>::incrementTime(unsigned int time) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Agent<Delay>::incrementTime(unsigned int time) {
     if (m_time + time < m_time) {
       throw std::overflow_error(buildLog("Time has reached its maximum value"));
     }

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -43,75 +43,75 @@ namespace dsm {
     /// @brief Construct a new Agent object
     /// @param id The agent's id
     /// @param itineraryId The agent's itinerary
-    inline Agent(Id id, Id itineraryId);
+    Agent(Id id, Id itineraryId);
     /// @brief Construct a new Agent object
     /// @param id The agent's id
     /// @param itineraryId The agent's itinerary
     /// @param srcNodeId The id of the source node of the agent
-    inline Agent(Id id, Id itineraryId, Id srcNodeId);
+    Agent(Id id, Id itineraryId, Id srcNodeId);
     /// @brief Set the street occupied by the agent
     /// @param streetId The id of the street currently occupied by the agent
-    inline void setStreetId(Id streetId) { m_streetId = streetId; }
+    void setStreetId(Id streetId) { m_streetId = streetId; }
     /// @brief Set the source node id of the agent
     /// @param srcNodeId The id of the source node of the agent
-    inline void setSourceNodeId(Id srcNodeId) { m_srcNodeId = srcNodeId; }
+    void setSourceNodeId(Id srcNodeId) { m_srcNodeId = srcNodeId; }
     /// @brief Set the agent's itinerary
     /// @param itineraryId The agent's itinerary
-    inline void setItineraryId(Id itineraryId) { m_itineraryId = itineraryId; }
+    void setItineraryId(Id itineraryId) { m_itineraryId = itineraryId; }
     /// @brief Set the agent's speed
     /// @param speed, The agent's speed
     /// @throw std::invalid_argument, if speed is negative
-    inline void setSpeed(double speed);
+    void setSpeed(double speed);
     /// @brief Increment the agent's delay by 1
     /// @throw std::overflow_error, if delay has reached its maximum value
-    inline void incrementDelay();
+    void incrementDelay();
     /// @brief Set the agent's delay
     /// @param delay The agent's delay
     /// @throw std::overflow_error, if delay has reached its maximum value
-    inline void incrementDelay(Delay delay);
+    void incrementDelay(Delay delay);
     /// @brief Decrement the agent's delay by 1
     /// @throw std::underflow_error, if delay has reached its minimum value
-    inline void decrementDelay();
+    void decrementDelay();
     /// @brief Increment the agent's distance by its speed * 1 second
-    inline void incrementDistance() { m_distance += m_speed; }
+    void incrementDistance() { m_distance += m_speed; }
     /// @brief Increment the agent's distance by a given value
     /// @param distance The value to increment the agent's distance byù
     /// @throw std::invalid_argument, if distance is negative
-    inline void incrementDistance(double distance);
+    void incrementDistance(double distance);
     /// @brief Increment the agent's time by 1
     /// @throw std::overflow_error, if time has reached its maximum value
-    inline void incrementTime();
+    void incrementTime();
     /// @brief Increment the agent's time by a given value
     /// @param time The value to increment the agent's time by
     /// @throw std::overflow_error, if time has reached its maximum value
-    inline void incrementTime(unsigned int time);
+    void incrementTime(unsigned int time);
     /// @brief Reset the agent's time to 0
-    inline void resetTime() { m_time = 0; }
+    void resetTime() { m_time = 0; }
 
     /// @brief Get the agent's id
     /// @return The agent's id
-    inline Id id() const { return m_id; }
+    Id id() const { return m_id; }
     /// @brief Get the agent's itinerary
     /// @return The agent's itinerary
-    inline Id itineraryId() const { return m_itineraryId; }
+    Id itineraryId() const { return m_itineraryId; }
     /// @brief Get the id of the street currently occupied by the agent
     /// @return The id of the street currently occupied by the agent
-    inline std::optional<Id> streetId() const { return m_streetId; }
+    std::optional<Id> streetId() const { return m_streetId; }
     /// @brief Get the id of the source node of the agent
     /// @return The id of the source node of the agent
-    inline std::optional<Id> srcNodeId() const { return m_srcNodeId; }
+    std::optional<Id> srcNodeId() const { return m_srcNodeId; }
     /// @brief Get the agent's speed
     /// @return The agent's speed
-    inline double speed() const { return m_speed; }
+    double speed() const { return m_speed; }
     /// @brief Get the agent's delay
     /// @return	The agent's delay
-    inline Delay delay() const { return m_delay; }
+    Delay delay() const { return m_delay; }
     /// @brief Get the agent's travelled distance
     /// @return The agent's travelled distance
-    inline double distance() const { return m_distance; }
+    double distance() const { return m_distance; }
     /// @brief Get the agent's travel time
     /// @return The agent's travel time
-    inline unsigned int time() const { return m_time; }
+    unsigned int time() const { return m_time; }
   };
 
   template <typename Delay>

--- a/src/dsm/headers/Agent.hpp
+++ b/src/dsm/headers/Agent.hpp
@@ -43,75 +43,75 @@ namespace dsm {
     /// @brief Construct a new Agent object
     /// @param id The agent's id
     /// @param itineraryId The agent's itinerary
-    Agent(Id id, Id itineraryId);
+    inline Agent(Id id, Id itineraryId);
     /// @brief Construct a new Agent object
     /// @param id The agent's id
     /// @param itineraryId The agent's itinerary
     /// @param srcNodeId The id of the source node of the agent
-    Agent(Id id, Id itineraryId, Id srcNodeId);
+    inline Agent(Id id, Id itineraryId, Id srcNodeId);
     /// @brief Set the street occupied by the agent
     /// @param streetId The id of the street currently occupied by the agent
-    void setStreetId(Id streetId) { m_streetId = streetId; }
+    inline void setStreetId(Id streetId) { m_streetId = streetId; }
     /// @brief Set the source node id of the agent
     /// @param srcNodeId The id of the source node of the agent
-    void setSourceNodeId(Id srcNodeId) { m_srcNodeId = srcNodeId; }
+    inline void setSourceNodeId(Id srcNodeId) { m_srcNodeId = srcNodeId; }
     /// @brief Set the agent's itinerary
     /// @param itineraryId The agent's itinerary
-    void setItineraryId(Id itineraryId) { m_itineraryId = itineraryId; }
+    inline void setItineraryId(Id itineraryId) { m_itineraryId = itineraryId; }
     /// @brief Set the agent's speed
     /// @param speed, The agent's speed
     /// @throw std::invalid_argument, if speed is negative
-    void setSpeed(double speed);
+    inline void setSpeed(double speed);
     /// @brief Increment the agent's delay by 1
     /// @throw std::overflow_error, if delay has reached its maximum value
-    void incrementDelay();
+    inline void incrementDelay();
     /// @brief Set the agent's delay
     /// @param delay The agent's delay
     /// @throw std::overflow_error, if delay has reached its maximum value
-    void incrementDelay(Delay delay);
+    inline void incrementDelay(Delay delay);
     /// @brief Decrement the agent's delay by 1
     /// @throw std::underflow_error, if delay has reached its minimum value
-    void decrementDelay();
+    inline void decrementDelay();
     /// @brief Increment the agent's distance by its speed * 1 second
-    void incrementDistance() { m_distance += m_speed; }
+    inline void incrementDistance() { m_distance += m_speed; }
     /// @brief Increment the agent's distance by a given value
     /// @param distance The value to increment the agent's distance byù
     /// @throw std::invalid_argument, if distance is negative
-    void incrementDistance(double distance);
+    inline void incrementDistance(double distance);
     /// @brief Increment the agent's time by 1
     /// @throw std::overflow_error, if time has reached its maximum value
-    void incrementTime();
+    inline void incrementTime();
     /// @brief Increment the agent's time by a given value
     /// @param time The value to increment the agent's time by
     /// @throw std::overflow_error, if time has reached its maximum value
-    void incrementTime(unsigned int time);
+    inline void incrementTime(unsigned int time);
     /// @brief Reset the agent's time to 0
-    void resetTime() { m_time = 0; }
+    inline void resetTime() { m_time = 0; }
 
     /// @brief Get the agent's id
     /// @return The agent's id
-    Id id() const { return m_id; }
+    inline Id id() const { return m_id; }
     /// @brief Get the agent's itinerary
     /// @return The agent's itinerary
-    Id itineraryId() const { return m_itineraryId; }
+    inline Id itineraryId() const { return m_itineraryId; }
     /// @brief Get the id of the street currently occupied by the agent
     /// @return The id of the street currently occupied by the agent
-    std::optional<Id> streetId() const { return m_streetId; }
+    inline std::optional<Id> streetId() const { return m_streetId; }
     /// @brief Get the id of the source node of the agent
     /// @return The id of the source node of the agent
-    std::optional<Id> srcNodeId() const { return m_srcNodeId; }
+    inline std::optional<Id> srcNodeId() const { return m_srcNodeId; }
     /// @brief Get the agent's speed
     /// @return The agent's speed
-    double speed() const { return m_speed; }
+    inline double speed() const { return m_speed; }
     /// @brief Get the agent's delay
     /// @return	The agent's delay
-    Delay delay() const { return m_delay; }
+    inline Delay delay() const { return m_delay; }
     /// @brief Get the agent's travelled distance
     /// @return The agent's travelled distance
-    double distance() const { return m_distance; }
+    inline double distance() const { return m_distance; }
     /// @brief Get the agent's travel time
     /// @return The agent's travel time
-    unsigned int time() const { return m_time; }
+    inline unsigned int time() const { return m_time; }
   };
 
   template <typename Delay>

--- a/src/dsm/headers/Dynamics.hpp
+++ b/src/dsm/headers/Dynamics.hpp
@@ -27,6 +27,7 @@
 #include "../utility/TypeTraits/is_agent.hpp"
 #include "../utility/TypeTraits/is_itinerary.hpp"
 #include "../utility/Logger.hpp"
+#include "../utility/Typedef.hpp"
 
 namespace dsm {
 
@@ -67,15 +68,14 @@ namespace dsm {
   /// @brief The Dynamics class represents the dynamics of the network.
   /// @tparam Id, The type of the graph's id. It must be an unsigned integral type.
   /// @tparam Size, The type of the graph's capacity. It must be an unsigned integral type.
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   class Dynamics {
   protected:
-    std::unordered_map<Id, std::unique_ptr<Itinerary<Id>>> m_itineraries;
-    std::map<Id, std::unique_ptr<Agent<Id, Size, Delay>>> m_agents;
+    std::unordered_map<Id, std::unique_ptr<Itinerary>> m_itineraries;
+    std::map<Id, std::unique_ptr<Agent<Delay>>> m_agents;
     TimePoint m_time, m_previousSpireTime;
-    Graph<Id, Size> m_graph;
+    Graph m_graph;
     double m_errorProbability;
     double m_minSpeedRateo;
     double m_maxFlowPercentage;
@@ -114,16 +114,16 @@ namespace dsm {
     virtual void m_evolveAgents();
     /// @brief Update the path of a single itinerary
     /// @param pItinerary An std::unique_prt to the itinerary
-    void m_updatePath(const std::unique_ptr<Itinerary<Id>>& pItinerary);
+    void m_updatePath(const std::unique_ptr<Itinerary>& pItinerary);
 
   public:
     /// @brief Construct a new Dynamics object
     /// @param graph The graph representing the network
-    Dynamics(Graph<Id, Size>& graph);
+    Dynamics(Graph& graph);
 
     /// @brief Set the itineraries
     /// @param itineraries The itineraries
-    void setItineraries(std::span<Itinerary<Id>> itineraries);
+    void setItineraries(std::span<Itinerary> itineraries);
     /// @brief Set the seed for the graph's random number generator
     /// @param seed The seed
     void setSeed(unsigned int seed) { m_generator.seed(seed); };
@@ -184,16 +184,16 @@ namespace dsm {
                                double densityTolerance = 0.);
 
     /// @brief Get the graph
-    /// @return const Graph<Id, Size>&, The graph
-    const Graph<Id, Size>& graph() const { return m_graph; };
+    /// @return const Graph&, The graph
+    const Graph& graph() const { return m_graph; };
     /// @brief Get the itineraries
-    /// @return const std::unordered_map<Id, Itinerary<Id>>&, The itineraries
-    const std::unordered_map<Id, std::unique_ptr<Itinerary<Id>>>& itineraries() const {
+    /// @return const std::unordered_map<Id, Itinerary>&, The itineraries
+    const std::unordered_map<Id, std::unique_ptr<Itinerary>>& itineraries() const {
       return m_itineraries;
     }
     /// @brief Get the agents
     /// @return const std::unordered_map<Id, Agent<Id>>&, The agents
-    const std::map<Id, std::unique_ptr<Agent<Id, Size, Delay>>>& agents() const {
+    const std::map<Id, std::unique_ptr<Agent<Delay>>>& agents() const {
       return m_agents;
     }
     /// @brief Get the time
@@ -202,10 +202,10 @@ namespace dsm {
 
     /// @brief Add an agent to the simulation
     /// @param agent The agent
-    void addAgent(const Agent<Id, Size, Delay>& agent);
+    void addAgent(const Agent<Delay>& agent);
     /// @brief Add an agent to the simulation
     /// @param agent std::unique_ptr to the agent
-    void addAgent(std::unique_ptr<Agent<Id, Size, Delay>> agent);
+    void addAgent(std::unique_ptr<Agent<Delay>> agent);
     /// @brief Add an agent with given source node and itinerary
     /// @param srcNodeId The id of the source node
     /// @param itineraryId The id of the itinerary
@@ -232,7 +232,7 @@ namespace dsm {
     void addAgents(T1 agent, Tn... agents);
     /// @brief Add a set of agents to the simulation
     /// @param agents Generic container of agents, represented by an std::span
-    void addAgents(std::span<Agent<Id, Size, Delay>> agents);
+    void addAgents(std::span<Agent<Delay>> agents);
     /// @brief Add a set of agents to the simulation
     /// @param nAgents The number of agents to add
     /// @param uniformly If true, the agents are added uniformly on the streets
@@ -259,10 +259,10 @@ namespace dsm {
 
     /// @brief Add an itinerary
     /// @param itinerary The itinerary
-    void addItinerary(const Itinerary<Id>& itinerary);
+    void addItinerary(const Itinerary& itinerary);
     /// @brief Add an itinerary
     /// @param itinerary std::unique_ptr to the itinerary
-    void addItinerary(std::unique_ptr<Itinerary<Id>> itinerary);
+    void addItinerary(std::unique_ptr<Itinerary> itinerary);
     template <typename... Tn>
       requires(is_itinerary_v<Tn> && ...)
     void addItineraries(Tn... itineraries);
@@ -276,7 +276,7 @@ namespace dsm {
     void addItineraries(T1 itinerary, Tn... itineraries);
     /// @brief Add a set of itineraries
     /// @param itineraries Generic container of itineraries, represented by an std::span
-    void addItineraries(std::span<Itinerary<Id>> itineraries);
+    void addItineraries(std::span<Itinerary> itineraries);
 
     /// @brief Reset the simulation time
     void resetTime();
@@ -340,10 +340,9 @@ namespace dsm {
     }
   };
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Dynamics<Id, Size, Delay>::Dynamics(Graph<Id, Size>& graph)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Dynamics<Delay>::Dynamics(Graph& graph)
       : m_time{0},
         m_previousSpireTime{0},
         m_graph{std::move(graph)},
@@ -382,10 +381,9 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Id Dynamics<Id, Size, Delay>::m_nextStreetId(Id agentId,
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Id Dynamics<Delay>::m_nextStreetId(Id agentId,
                                                Id nodeId,
                                                std::optional<Id> streetId) {
     auto possibleMoves = m_graph.adjMatrix().getRow(nodeId, true);
@@ -413,10 +411,9 @@ namespace dsm {
     return iterator->first;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::m_increaseTurnCounts(Id streetId, double delta) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::m_increaseTurnCounts(Id streetId, double delta) {
     if (std::abs(delta) < std::numbers::pi) {
       if (delta < 0.) {
         ++m_turnCounts[streetId][0];  // right
@@ -430,10 +427,9 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::m_evolveStreets(bool reinsert_agents) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::m_evolveStreets(bool reinsert_agents) {
     for (const auto& [streetId, street] : m_graph.streetSet()) {
       if (m_uniformDist(m_generator) > m_maxFlowPercentage || street->queue().empty()) {
         continue;
@@ -454,7 +450,7 @@ namespace dsm {
         continue;
       }
       if (destinationNode->isTrafficLight()) {
-        auto& tl = dynamic_cast<TrafficLight<Id, Size, Delay>&>(*destinationNode);
+        auto& tl = dynamic_cast<TrafficLight<Delay>&>(*destinationNode);
         if (!tl.isGreen(streetId)) {
           continue;
         }
@@ -465,7 +461,7 @@ namespace dsm {
         m_travelTimes.push_back(m_agents[agentId]->time());
         if (reinsert_agents) {
           // take last agent id in map
-          Agent<Id, Size, Delay> newAgent{static_cast<Id>(m_agents.rbegin()->first + 1),
+          Agent<Delay> newAgent{static_cast<Id>(m_agents.rbegin()->first + 1),
                                           m_agents[agentId]->itineraryId(),
                                           m_agents[agentId]->srcNodeId().value()};
           if (m_agents[agentId]->srcNodeId().has_value()) {
@@ -486,7 +482,7 @@ namespace dsm {
       street->dequeue();
       assert(destinationNode->id() == nextStreet->nodePair().first);
       if (destinationNode->isIntersection()) {
-        auto& intersection = dynamic_cast<Node<Id, Size>&>(*destinationNode);
+        auto& intersection = dynamic_cast<Node&>(*destinationNode);
         auto delta = nextStreet->angle() - street->angle();
         if (delta > std::numbers::pi) {
           delta -= 2 * std::numbers::pi;
@@ -497,19 +493,18 @@ namespace dsm {
         intersection.addAgent(delta, agentId);
         m_agentNextStreetId.emplace(agentId, nextStreet->id());
       } else if (destinationNode->isRoundabout()) {
-        auto& roundabout = dynamic_cast<Roundabout<Id, Size>&>(*destinationNode);
+        auto& roundabout = dynamic_cast<Roundabout&>(*destinationNode);
         roundabout.enqueue(agentId);
       }
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::m_evolveNodes() {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::m_evolveNodes() {
     for (const auto& [nodeId, node] : m_graph.nodeSet()) {
       if (node->isIntersection()) {
-        auto& intersection = dynamic_cast<Node<Id, Size>&>(*node);
+        auto& intersection = dynamic_cast<Node&>(*node);
         for (const auto [angle, agentId] : intersection.agents()) {
           const auto& nextStreet{m_graph.streetSet()[m_agentNextStreetId[agentId]]};
           if (!(nextStreet->isFull())) {
@@ -525,11 +520,11 @@ namespace dsm {
           }
         }
         if (node->isTrafficLight()) {
-          auto& tl = dynamic_cast<TrafficLight<Id, Size, Delay>&>(*node);
+          auto& tl = dynamic_cast<TrafficLight<Delay>&>(*node);
           tl.increaseCounter();
         }
       } else if (node->isRoundabout()) {
-        auto& roundabout = dynamic_cast<Roundabout<Id, Size>&>(*node);
+        auto& roundabout = dynamic_cast<Roundabout&>(*node);
         const auto nAgents{roundabout.agents().size()};
         for (size_t i{0}; i < nAgents; ++i) {
           const auto agentId{roundabout.agents().front()};
@@ -560,10 +555,9 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::m_evolveAgents() {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::m_evolveAgents() {
     for (const auto& [agentId, agent] : this->m_agents) {
       if (agent->delay() > 0) {
         const auto& street{m_graph.streetSet()[agent->streetId().value()]};
@@ -594,7 +588,7 @@ namespace dsm {
         }
         assert(srcNode->id() == nextStreet->nodePair().first);
         if (srcNode->isIntersection()) {
-          auto& intersection = dynamic_cast<Node<Id, Size>&>(*srcNode);
+          auto& intersection = dynamic_cast<Node&>(*srcNode);
           try {
             intersection.addAgent(0., agentId);
             m_agentNextStreetId.emplace(agentId, nextStreet->id());
@@ -602,7 +596,7 @@ namespace dsm {
             continue;
           }
         } else if (srcNode->isRoundabout()) {
-          auto& roundabout = dynamic_cast<Roundabout<Id, Size>&>(*srcNode);
+          auto& roundabout = dynamic_cast<Roundabout&>(*srcNode);
           try {
             roundabout.enqueue(agentId);
           } catch (...) {
@@ -616,74 +610,70 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::m_updatePath(
-      const std::unique_ptr<Itinerary<Id>>& pItinerary) {
-    const Size dimension = m_graph.adjMatrix().getRowDim();
-    const auto destinationID = pItinerary->destination();
-    SparseMatrix<Id, bool> path{dimension, dimension};
-    // cycle over the nodes
-    for (const auto& [nodeId, node] : m_graph.nodeSet()) {
-      if (nodeId == destinationID) {
-        continue;
-      }
-      auto result{m_graph.shortestPath(nodeId, destinationID)};
-      if (!result.has_value()) {
-        continue;
-      }
-      // save the minimum distance between i and the destination
-      const auto minDistance{result.value().distance()};
-      for (const auto [nextNodeId, _] : m_graph.adjMatrix().getRow(nodeId)) {
-        if (nextNodeId == destinationID &&
-            minDistance ==
-                m_graph.streetSet().at(nodeId * dimension + nextNodeId)->length()) {
-          path.insert(nodeId, nextNodeId, true);
-          continue;
-        }
-        // TimePoint expectedTravelTime{
-        //     streetLength};  // / street->maxSpeed()};  // TODO: change into input speed
-        result = m_graph.shortestPath(nextNodeId, destinationID);
+  /* template <typename Delay> */
+  /*   requires is_numeric_v<Delay> */
+  /* void Dynamics<Delay>::m_updatePath(const std::unique_ptr<Itinerary>>& pItinerary) { */
+  /*   const Size dimension = m_graph.adjMatrix().getRowDim(); */
+  /*   const auto destinationID = pItinerary->destination(); */
+  /*   SparseMatrix<bool> path{dimension, dimension}; */
+  /*   // cycle over the nodes */
+  /*   for (const auto& [nodeId, node] : m_graph.nodeSet()) { */
+  /*     if (nodeId == destinationID) { */
+  /*       continue; */
+  /*     } */
+  /*     auto result{m_graph.shortestPath(nodeId, destinationID)}; */
+  /*     if (!result.has_value()) { */
+  /*       continue; */
+  /*     } */
+  /*     // save the minimum distance between i and the destination */
+  /*     const auto minDistance{result.value().distance()}; */
+  /*     for (const auto [nextNodeId, _] : m_graph.adjMatrix().getRow(nodeId)) { */
+  /*       if (nextNodeId == destinationID && */
+  /*           minDistance == */
+  /*               m_graph.streetSet().at(nodeId * dimension + nextNodeId)->length()) { */
+  /*         path.insert(nodeId, nextNodeId, true); */
+  /*         continue; */
+  /*       } */
+  /*       // TimePoint expectedTravelTime{ */
+  /*       //     streetLength};  // / street->maxSpeed()};  // TODO: change into input speed */
+  /*       result = m_graph.shortestPath(nextNodeId, destinationID); */
 
-        if (result.has_value()) {
-          // if the shortest path exists, save the distance
-          if (minDistance ==
-              result.value().distance() +
-                  m_graph.streetSet().at(nodeId * dimension + nextNodeId)->length()) {
-            path.insert(nodeId, nextNodeId, true);
-          }
-        } else if ((nextNodeId != destinationID)) {
-          std::cerr << std::format("WARNING: No path found from node {} to node {}",
-                                   nextNodeId,
-                                   destinationID)
-                    << std::endl;
-        }
-      }
-    }
-    if (path.size() == 0) {
-      throw std::runtime_error(
-          buildLog(std::format("Path with id {} and destination {} is empty. Please "
-                               "check the adjacency matrix.",
-                               pItinerary->id(),
-                               pItinerary->destination())));
-    }
-    pItinerary->setPath(path);
-  }
+  /*       if (result.has_value()) { */
+  /*         // if the shortest path exists, save the distance */
+  /*         if (minDistance == */
+  /*             result.value().distance() + */
+  /*                 m_graph.streetSet().at(nodeId * dimension + nextNodeId)->length()) { */
+  /*           path.insert(nodeId, nextNodeId, true); */
+  /*         } */
+  /*       } else if ((nextNodeId != destinationID)) { */
+  /*         std::cerr << std::format("WARNING: No path found from node {} to node {}", */
+  /*                                  nextNodeId, */
+  /*                                  destinationID) */
+  /*                   << std::endl; */
+  /*       } */
+  /*     } */
+  /*   } */
+  /*   if (path.size() == 0) { */
+  /*     throw std::runtime_error( */
+  /*         buildLog(std::format("Path with id {} and destination {} is empty. Please " */
+  /*                              "check the adjacency matrix.", */
+  /*                              pItinerary->id(), */
+  /*                              pItinerary->destination()))); */
+  /*   } */
+  /*   pItinerary->setPath(path); */
+  /* } */
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::setItineraries(std::span<Itinerary<Id>> itineraries) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::setItineraries(std::span<Itinerary> itineraries) {
     std::ranges::for_each(itineraries, [this](const auto& itinerary) {
-      this->m_itineraries.insert(std::make_unique<Itinerary<Id>>(itinerary));
+      this->m_itineraries.insert(std::make_unique<Itinerary>(itinerary));
     });
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::setMinSpeedRateo(double minSpeedRateo) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::setMinSpeedRateo(double minSpeedRateo) {
     if (minSpeedRateo < 0. || minSpeedRateo > 1.) {
       throw std::invalid_argument(buildLog(std::format(
           "The minimum speed rateo ({}) must be between 0 and 1", minSpeedRateo)));
@@ -691,10 +681,9 @@ namespace dsm {
     m_minSpeedRateo = minSpeedRateo;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::setErrorProbability(double errorProbability) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::setErrorProbability(double errorProbability) {
     if (errorProbability < 0. || errorProbability > 1.) {
       throw std::invalid_argument(buildLog(std::format(
           "The error probability ({}) must be between 0 and 1", errorProbability)));
@@ -702,10 +691,9 @@ namespace dsm {
     m_errorProbability = errorProbability;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::setMaxFlowPercentage(double maxFlowPercentage) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::setMaxFlowPercentage(double maxFlowPercentage) {
     if (maxFlowPercentage < 0. || maxFlowPercentage > 1.) {
       throw std::invalid_argument(
           buildLog(std::format("The maximum flow percentage ({}) must be between 0 and 1",
@@ -714,27 +702,25 @@ namespace dsm {
     m_maxFlowPercentage = maxFlowPercentage;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::setDestinationNodes(
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::setDestinationNodes(
       const std::span<Id>& destinationNodes, bool updatePaths) {
     for (const auto& nodeId : destinationNodes) {
       if (!m_graph.nodeSet().contains(nodeId)) {
         throw std::invalid_argument(
             buildLog(std::format("Node with id {} not found", nodeId)));
       }
-      this->addItinerary(Itinerary<Id>{nodeId, nodeId});
+      this->addItinerary(Itinerary{nodeId, nodeId});
     }
     if (updatePaths) {
       this->updatePaths();
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::updatePaths() {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::updatePaths() {
     std::vector<std::thread> threads;
     threads.reserve(m_itineraries.size());
     std::exception_ptr pThreadException;
@@ -756,10 +742,9 @@ namespace dsm {
       std::rethrow_exception(pThreadException);
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::evolve(bool reinsert_agents) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::evolve(bool reinsert_agents) {
     // move the first agent of each street queue, if possible, putting it in the next node
     this->m_evolveStreets(reinsert_agents);
     // move all the agents from each node, if possible
@@ -770,10 +755,9 @@ namespace dsm {
     ++this->m_time;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::optimizeTrafficLights(Delay nCycles,
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::optimizeTrafficLights(Delay nCycles,
                                                         double threshold,
                                                         double densityTolerance) {
     if (threshold < 0 || threshold > 1) {
@@ -793,7 +777,7 @@ namespace dsm {
       if (!node->isTrafficLight()) {
         continue;
       }
-      auto& tl = dynamic_cast<TrafficLight<Id, Size, Delay>&>(*node);
+      auto& tl = dynamic_cast<TrafficLight<Delay>&>(*node);
       if (!tl.delay().has_value()) {
         continue;
       }
@@ -902,10 +886,9 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addAgent(const Agent<Id, Size, Delay>& agent) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addAgent(const Agent<Delay>& agent) {
     if (this->m_agents.size() + 1 > this->m_graph.maxCapacity()) {
       throw std::overflow_error(buildLog(
           std::format("Graph its already holding the max possible number of agents ({})",
@@ -915,12 +898,11 @@ namespace dsm {
       throw std::invalid_argument(
           buildLog(std::format("Agent with id {} already exists.", agent.id())));
     }
-    this->m_agents.emplace(agent.id(), std::make_unique<Agent<Id, Size, Delay>>(agent));
+    this->m_agents.emplace(agent.id(), std::make_unique<Agent<Delay>>(agent));
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addAgent(std::unique_ptr<Agent<Id, Size, Delay>> agent) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addAgent(std::unique_ptr<Agent<Delay>> agent) {
     if (this->m_agents.size() + 1 > this->m_graph.maxCapacity()) {
       throw std::overflow_error(buildLog(
           std::format("Graph its already holding the max possible number of agents ({})",
@@ -932,10 +914,9 @@ namespace dsm {
     }
     this->m_agents.emplace(agent->id(), std::move(agent));
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addAgent(Id srcNodeId, Id itineraryId) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addAgent(Id srcNodeId, Id itineraryId) {
     if (this->m_agents.size() + 1 > this->m_graph.maxCapacity()) {
       throw std::overflow_error(buildLog(
           std::format("Graph its already holding the max possible number of agents ({})",
@@ -953,12 +934,11 @@ namespace dsm {
     if (!this->m_agents.empty()) {
       agentId = this->m_agents.rbegin()->first + 1;
     }
-    this->addAgent(Agent<Id, Size, Delay>{agentId, itineraryId, srcNodeId});
+    this->addAgent(Agent<Delay>{agentId, itineraryId, srcNodeId});
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addAgents(Id itineraryId,
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addAgents(Id itineraryId,
                                             Size nAgents,
                                             std::optional<Id> srcNodeId) {
     if (this->m_agents.size() + nAgents > this->m_graph.maxCapacity()) {
@@ -976,34 +956,31 @@ namespace dsm {
       agentId = this->m_agents.rbegin()->first + 1;
     }
     for (Size i{0}; i < nAgents; ++i, ++agentId) {
-      this->addAgent(Agent<Id, Size, Delay>{agentId, itineraryId});
+      this->addAgent(Agent<Delay>{agentId, itineraryId});
       if (srcNodeId.has_value()) {
         this->m_agents[agentId]->setSourceNodeId(srcNodeId.value());
       }
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   template <typename... Tn>
     requires(is_agent_v<Tn> && ...)
-  void Dynamics<Id, Size, Delay>::addAgents(Tn... agents) {}
+  void Dynamics<Delay>::addAgents(Tn... agents) {}
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   template <typename T1, typename... Tn>
     requires(is_agent_v<T1> && (is_agent_v<Tn> && ...))
-  void Dynamics<Id, Size, Delay>::addAgents(T1 agent, Tn... agents) {
+  void Dynamics<Delay>::addAgents(T1 agent, Tn... agents) {
     addAgent(agent);
     addAgents(agents...);
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addAgents(std::span<Agent<Id, Size, Delay>> agents) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addAgents(std::span<Agent<Delay>> agents) {
     if (this->m_agents.size() + agents.size() > this->m_graph.maxCapacity()) {
       throw std::overflow_error(buildLog(
           std::format("Graph its already holding the max possible number of agents ({})",
@@ -1014,10 +991,9 @@ namespace dsm {
     });
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addAgentsUniformly(Size nAgents,
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addAgentsUniformly(Size nAgents,
                                                      std::optional<Id> itineraryId) {
     if (this->m_agents.size() + nAgents > this->m_graph.maxCapacity()) {
       throw std::overflow_error(buildLog(
@@ -1055,7 +1031,7 @@ namespace dsm {
         streetId = streetIt->first;
       } while (this->m_graph.streetSet()[streetId]->isFull());
       const auto& street{this->m_graph.streetSet()[streetId]};
-      Agent<Id, Size, Delay> agent{
+      Agent<Delay> agent{
           agentId, itineraryId.value(), street->nodePair().first};
       agent.setStreetId(streetId);
       this->addAgent(agent);
@@ -1067,13 +1043,12 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   template <typename TContainer>
     requires(std::is_same_v<TContainer, std::unordered_map<Id, double>> ||
              std::is_same_v<TContainer, std::map<Id, double>>)
-  void Dynamics<Id, Size, Delay>::addAgentsRandomly(Size nAgents,
+  void Dynamics<Delay>::addAgentsRandomly(Size nAgents,
                                                     const TContainer& src_weights,
                                                     const TContainer& dst_weights) {
     // Check if the weights are normalized
@@ -1130,10 +1105,9 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::removeAgent(Size agentId) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::removeAgent(Size agentId) {
     auto agentIt{m_agents.find(agentId)};
     if (agentIt == m_agents.end()) {
       throw std::invalid_argument(
@@ -1142,68 +1116,61 @@ namespace dsm {
     m_agents.erase(agentId);
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   template <typename T1, typename... Tn>
     requires(std::is_convertible_v<T1, Size> && (std::is_convertible_v<Tn, Size> && ...))
-  void Dynamics<Id, Size, Delay>::removeAgents(T1 id, Tn... ids) {
+  void Dynamics<Delay>::removeAgents(T1 id, Tn... ids) {
     removeAgent(id);
     removeAgents(ids...);
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addItinerary(const Itinerary<Id>& itinerary) {
-    m_itineraries.emplace(itinerary.id(), std::make_unique<Itinerary<Id>>(itinerary));
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addItinerary(const Itinerary& itinerary) {
+    m_itineraries.emplace(itinerary.id(), std::make_unique<Itinerary>(itinerary));
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addItinerary(std::unique_ptr<Itinerary<Id>> itinerary) {
-    m_itineraries.emplace(itinerary.id(), std::move(itinerary));
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addItinerary(std::unique_ptr<Itinerary> itinerary) {
+    m_itineraries.emplace(itinerary->id(), std::move(itinerary));
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   template <typename... Tn>
     requires(is_itinerary_v<Tn> && ...)
-  void Dynamics<Id, Size, Delay>::addItineraries(Tn... itineraries) {
+  void Dynamics<Delay>::addItineraries(Tn... itineraries) {
     (this->addItinerary(itineraries), ...);
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::addItineraries(std::span<Itinerary<Id>> itineraries) {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::addItineraries(std::span<Itinerary> itineraries) {
     std::ranges::for_each(itineraries, [this](const auto& itinerary) -> void {
-      this->m_itineraries.push_back(std::make_unique<Itinerary<Id>>(itinerary));
+      this->m_itineraries.insert(std::make_unique<Itinerary>(itinerary));
     });
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  void Dynamics<Id, Size, Delay>::resetTime() {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  void Dynamics<Delay>::resetTime() {
     m_time = 0;
   }
 
-  // template <typename Id, typename Size, typename Delay>
-  //   requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  // template <typename Delay>
+  //   requires(
   //            is_numeric_v<Delay>)
   // template <typename F, typename... Tn>
   //   requires(std::is_invocable_v<F, Tn...>)
-  // void Dynamics<Id, Size, Delay>::evolve(F f, Tn... args) {
+  // void Dynamics<Delay>::evolve(F f, Tn... args) {
   //   f(args...);
   // }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Measurement<double> Dynamics<Id, Size, Delay>::agentMeanSpeed() const {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Measurement<double> Dynamics<Delay>::agentMeanSpeed() const {
     if (m_agents.size() == 0) {
       return Measurement(0., 0.);
     }
@@ -1228,10 +1195,9 @@ namespace dsm {
     return Measurement(mean, std::sqrt(variance));
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Measurement<double> Dynamics<Id, Size, Delay>::streetMeanDensity() const {
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Measurement<double> Dynamics<Delay>::streetMeanDensity() const {
     if (m_graph.streetSet().size() == 0) {
       return Measurement(0., 0.);
     }
@@ -1252,10 +1218,10 @@ namespace dsm {
         (m_graph.streetSet().size() - 1)};
     return Measurement(mean, std::sqrt(variance));
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Measurement<double> Dynamics<Id, Size, Delay>::streetMeanFlow() const {
+
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Measurement<double> Dynamics<Delay>::streetMeanFlow() const {
     std::vector<double> flows;
     flows.reserve(m_graph.streetSet().size());
     for (const auto& [streetId, street] : m_graph.streetSet()) {
@@ -1263,10 +1229,10 @@ namespace dsm {
     }
     return Measurement(flows);
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Measurement<double> Dynamics<Id, Size, Delay>::streetMeanFlow(double threshold,
+
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Measurement<double> Dynamics<Delay>::streetMeanFlow(double threshold,
                                                                 bool above) const {
     std::vector<double> flows;
     flows.reserve(m_graph.streetSet().size());
@@ -1279,10 +1245,10 @@ namespace dsm {
     }
     return Measurement(flows);
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Measurement<double> Dynamics<Id, Size, Delay>::meanSpireInputFlow(bool resetValue) {
+
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Measurement<double> Dynamics<Delay>::meanSpireInputFlow(bool resetValue) {
     auto deltaTime{m_time - m_previousSpireTime};
     if (deltaTime == 0) {
       return Measurement(0., 0.);
@@ -1292,16 +1258,16 @@ namespace dsm {
     flows.reserve(m_graph.streetSet().size());
     for (const auto& [streetId, street] : m_graph.streetSet()) {
       if (street->isSpire()) {
-        auto& spire = dynamic_cast<SpireStreet<Id, Size>&>(*street);
+        auto& spire = dynamic_cast<SpireStreet&>(*street);
         flows.push_back(static_cast<double>(spire.inputCounts(resetValue)) / deltaTime);
       }
     }
     return Measurement(flows);
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Measurement<double> Dynamics<Id, Size, Delay>::meanSpireOutputFlow(bool resetValue) {
+
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Measurement<double> Dynamics<Delay>::meanSpireOutputFlow(bool resetValue) {
     auto deltaTime{m_time - m_previousSpireTime};
     if (deltaTime == 0) {
       return Measurement(0., 0.);
@@ -1311,16 +1277,16 @@ namespace dsm {
     flows.reserve(m_graph.streetSet().size());
     for (const auto& [streetId, street] : m_graph.streetSet()) {
       if (street->isSpire()) {
-        auto& spire = dynamic_cast<SpireStreet<Id, Size>&>(*street);
+        auto& spire = dynamic_cast<SpireStreet&>(*street);
         flows.push_back(static_cast<double>(spire.outputCounts(resetValue)) / deltaTime);
       }
     }
     return Measurement(flows);
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
-  Measurement<double> Dynamics<Id, Size, Delay>::meanTravelTime(bool clearData) {
+
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
+  Measurement<double> Dynamics<Delay>::meanTravelTime(bool clearData) {
     if (m_travelTimes.size() == 0) {
       return Measurement(0., 0.);
     }
@@ -1338,11 +1304,11 @@ namespace dsm {
     }
     return Measurement(mean, std::sqrt(variance));
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   std::unordered_map<Id, std::array<double, 4>>
-  Dynamics<Id, Size, Delay>::turnProbabilities(bool reset) {
+  Dynamics<Delay>::turnProbabilities(bool reset) {
     std::unordered_map<Id, std::array<double, 4>> res;
     for (auto& [streetId, counts] : m_turnCounts) {
       std::array<double, 4> probabilities{0., 0., 0., 0.};
@@ -1362,17 +1328,16 @@ namespace dsm {
     return res;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
-  class FirstOrderDynamics : public Dynamics<Id, Size, Delay> {
+  template <typename Delay>
+    requires(std::unsigned_integral<Delay>)
+  class FirstOrderDynamics : public Dynamics<Delay> {
     double m_speedFluctuationSTD;
 
   public:
     /// @brief Construct a new First Order Dynamics object
     /// @param graph, The graph representing the network
-    FirstOrderDynamics(Graph<Id, Size>& graph)
-        : Dynamics<Id, Size, Delay>(graph), m_speedFluctuationSTD{0.} {};
+    FirstOrderDynamics(Graph& graph)
+        : Dynamics<Delay>(graph), m_speedFluctuationSTD{0.} {};
     /// @brief Set the speed of an agent
     /// @param agentId The id of the agent
     /// @throw std::invalid_argument, If the agent is not found
@@ -1398,10 +1363,9 @@ namespace dsm {
     Measurement<double> streetMeanSpeed(double threshold, bool above) const override;
   };
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
-  void FirstOrderDynamics<Id, Size, Delay>::setAgentSpeed(Size agentId) {
+  template <typename Delay>
+    requires(std::unsigned_integral<Delay>)
+  void FirstOrderDynamics<Delay>::setAgentSpeed(Size agentId) {
     const auto& agent{this->m_agents[agentId]};
     const auto& street{this->m_graph.streetSet()[agent->streetId().value()]};
     double speed{street->maxSpeed() *
@@ -1415,10 +1379,9 @@ namespace dsm {
                : agent->setSpeed(speed);
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
-  void FirstOrderDynamics<Id, Size, Delay>::setSpeedFluctuationSTD(
+  template <typename Delay>
+    requires(std::unsigned_integral<Delay>)
+  void FirstOrderDynamics<Delay>::setSpeedFluctuationSTD(
       double speedFluctuationSTD) {
     if (speedFluctuationSTD < 0.) {
       throw std::invalid_argument(
@@ -1427,10 +1390,9 @@ namespace dsm {
     m_speedFluctuationSTD = speedFluctuationSTD;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
-  double FirstOrderDynamics<Id, Size, Delay>::streetMeanSpeed(Id streetId) const {
+  template <typename Delay>
+    requires(std::unsigned_integral<Delay>)
+  double FirstOrderDynamics<Delay>::streetMeanSpeed(Id streetId) const {
     const auto& street{this->m_graph.streetSet().at(streetId)};
     if (street->nAgents() == 0) {
       return street->maxSpeed();
@@ -1453,7 +1415,7 @@ namespace dsm {
     }
     const auto& node = this->m_graph.nodeSet().at(street->nodePair().second);
     if (node->isIntersection()) {
-      auto& intersection = dynamic_cast<Node<Id, Size>&>(*node);
+      auto& intersection = dynamic_cast<Node&>(*node);
       for (const auto& [angle, agentId] : intersection.agents()) {
         const auto& agent{this->m_agents.at(agentId)};
         if (agent->streetId().has_value() && agent->streetId().value() == streetId) {
@@ -1462,7 +1424,7 @@ namespace dsm {
         }
       }
     } else if (node->isRoundabout()) {
-      auto& roundabout = dynamic_cast<Roundabout<Id, Size>&>(*node);
+      auto& roundabout = dynamic_cast<Roundabout&>(*node);
       for (const auto& agentId : roundabout.agents()) {
         const auto& agent{this->m_agents.at(agentId)};
         if (agent->streetId().has_value() && agent->streetId().value() == streetId) {
@@ -1474,10 +1436,9 @@ namespace dsm {
     return meanSpeed / n;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
-  Measurement<double> FirstOrderDynamics<Id, Size, Delay>::streetMeanSpeed() const {
+  template <typename Delay>
+    requires(std::unsigned_integral<Delay>)
+  Measurement<double> FirstOrderDynamics<Delay>::streetMeanSpeed() const {
     if (this->m_agents.size() == 0) {
       return Measurement(0., 0.);
     }
@@ -1488,10 +1449,9 @@ namespace dsm {
     }
     return Measurement(speeds);
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             std::unsigned_integral<Delay>)
-  Measurement<double> FirstOrderDynamics<Id, Size, Delay>::streetMeanSpeed(
+  template <typename Delay>
+    requires(std::unsigned_integral<Delay>)
+  Measurement<double> FirstOrderDynamics<Delay>::streetMeanSpeed(
       double threshold, bool above) const {
     if (this->m_agents.size() == 0) {
       return Measurement(0., 0.);
@@ -1512,20 +1472,14 @@ namespace dsm {
     return Measurement(speeds);
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  class SecondOrderDynamics : public Dynamics<Id, Size, double> {
-  public:
-    void setAgentSpeed(Size agentId);
-    void setSpeed();
-  };
+  /* class SecondOrderDynamics : public Dynamics<double> { */
+  /* public: */
+  /*   void setAgentSpeed(Size agentId); */
+  /*   void setSpeed(); */
+  /* }; */
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void SecondOrderDynamics<Id, Size>::setAgentSpeed(Size agentId) {}
+  /* void SecondOrderDynamics::setAgentSpeed(Size agentId) {} */
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void SecondOrderDynamics<Id, Size>::setSpeed() {}
+  /* void SecondOrderDynamics::setSpeed() {} */
 
 };  // namespace dsm

--- a/src/dsm/headers/Graph.cpp
+++ b/src/dsm/headers/Graph.cpp
@@ -405,8 +405,8 @@ namespace dsm {
     return this->street(nodePair.second, nodePair.first);
   }
 
-  std::optional<DijkstraResult> Graph::shortestPath(const Intersection& source,
-                                                    const Intersection& destination) const {
+  std::optional<DijkstraResult> Graph::shortestPath(
+      const Intersection& source, const Intersection& destination) const {
     return this->shortestPath(source.id(), destination.id());
   }
 

--- a/src/dsm/headers/Graph.cpp
+++ b/src/dsm/headers/Graph.cpp
@@ -1,0 +1,510 @@
+
+#include "Graph.hpp"
+
+namespace dsm {
+  Graph::Graph()
+      : m_adjacency{SparseMatrix<bool>()},
+        m_maxAgentCapacity{std::numeric_limits<unsigned long long>::max()} {}
+
+  Graph::Graph(const SparseMatrix<bool>& adj)
+      : m_adjacency{adj},
+        m_maxAgentCapacity{std::numeric_limits<unsigned long long>::max()} {
+    assert(adj.getRowDim() == adj.getColDim());
+    auto n{static_cast<Size>(adj.getRowDim())};
+    for (const auto& [id, value] : adj) {
+      const auto srcId{static_cast<Id>(id / n)};
+      const auto dstId{static_cast<Id>(id % n)};
+      if (!m_nodes.contains(srcId)) {
+        m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
+      }
+      if (!m_nodes.contains(dstId)) {
+        m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
+      }
+      m_streets.emplace(id, std::make_unique<Street>(id, std::make_pair(srcId, dstId)));
+    }
+  }
+
+  Graph::Graph(const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet)
+      : m_adjacency{SparseMatrix<bool>()} {
+    for (auto& street : streetSet) {
+      m_streets.emplace(street.second->id(), street.second.get());
+
+      Id node1 = street.second->nodePair().first;
+      Id node2 = street.second->nodePair().second;
+      m_nodes.emplace(node1, std::make_unique<Node>(node1));
+      m_nodes.emplace(node2, std::make_unique<Node>(node2));
+    }
+
+    buildAdj();
+  }
+
+  void Graph::m_reassignIds() {
+    // not sure about this, might need a bit more work
+    const auto oldStreetSet{std::move(m_streets)};
+    m_streets.clear();
+    const auto n{static_cast<Size>(m_nodes.size())};
+    std::unordered_map<Id, Id> newStreetIds;
+    for (const auto& [streetId, street] : oldStreetSet) {
+      const auto srcId{street->nodePair().first};
+      const auto dstId{street->nodePair().second};
+      const auto newStreetId{static_cast<Id>(srcId * n + dstId)};
+      if (m_streets.contains(newStreetId)) {
+        throw std::invalid_argument(buildLog("Street with same id already exists."));
+      }
+      auto newStreet = Street(newStreetId, *street);
+      m_streets.emplace(newStreetId, std::make_unique<Street>(newStreet));
+      newStreetIds.emplace(streetId, newStreetId);
+    }
+    for (const auto& [nodeId, node] : m_nodes) {
+      // This is probably not the best way to do this
+      if (node->isIntersection()) {
+        auto& intersection = dynamic_cast<Node&>(*node);
+        const auto& oldStreetPriorities{intersection.streetPriorities()};
+        std::set<Id> newStreetPriorities;
+        for (const auto streetId : oldStreetPriorities) {
+          newStreetPriorities.emplace(newStreetIds[streetId]);
+        }
+        intersection.setStreetPriorities(newStreetPriorities);
+      }
+    }
+  }
+
+  void Graph::m_setStreetAngles() {
+    for (const auto& [streetId, street] : m_streets) {
+      const auto& srcNode{m_nodes[street->nodePair().first]};
+      const auto& dstNode{m_nodes[street->nodePair().second]};
+      if (srcNode->coords().has_value() && dstNode->coords().has_value()) {
+        street->setAngle(srcNode->coords().value(), dstNode->coords().value());
+      }
+    }
+  }
+
+  void Graph::buildAdj() {
+    // find max values in streets node pairs
+    m_maxAgentCapacity = 0;
+    const auto maxNode{static_cast<Id>(m_nodes.size())};
+    m_adjacency.reshape(maxNode, maxNode);
+    for (const auto& [streetId, street] : m_streets) {
+      m_maxAgentCapacity += street->capacity();
+      m_adjacency.insert(street->nodePair().first, street->nodePair().second, true);
+    }
+    this->m_reassignIds();
+    this->m_setStreetAngles();
+  }
+
+  void Graph::buildStreetAngles() {
+    for (const auto& street : m_streets) {
+      const auto& node1{m_nodes[street.second->nodePair().first]};
+      const auto& node2{m_nodes[street.second->nodePair().second]};
+      street.second->setAngle(node1->coords().value(), node2->coords().value());
+    }
+  }
+
+  void Graph::importMatrix(const std::string& fileName, bool isAdj) {
+    // check the file extension
+    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
+    if (fileExt == "dsm") {
+      std::ifstream file{fileName};
+      if (!file.is_open()) {
+        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
+      }
+      Size rows, cols;
+      file >> rows >> cols;
+      if (rows != cols) {
+        throw std::invalid_argument(buildLog("Adjacency matrix must be square"));
+      }
+      Size n{rows};
+      m_adjacency = SparseMatrix<bool>(n, n);
+      // each line has 2 elements
+      while (!file.eof()) {
+        Id index;
+        double val;
+        file >> index >> val;
+        m_adjacency.insert(index, val);
+        const auto srcId{static_cast<Id>(index / n)};
+        const auto dstId{static_cast<Id>(index % n)};
+        if (!m_nodes.contains(srcId)) {
+          m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
+        }
+        if (!m_nodes.contains(dstId)) {
+          m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
+        }
+        m_streets.emplace(index,
+                          std::make_unique<Street>(index, std::make_pair(srcId, dstId)));
+        assert(index == srcId * n + dstId);
+        if (!isAdj) {
+          m_streets[index]->setLength(val);
+        }
+      }
+    } else {
+      // default case: read the file as a matrix with the first two elements being the number of rows and columns and
+      // the following elements being the matrix elements
+      std::ifstream file{fileName};
+      if (!file.is_open()) {
+        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
+      }
+      Size rows, cols;
+      file >> rows >> cols;
+      if (rows != cols) {
+        throw std::invalid_argument(
+            buildLog("Adjacency matrix must be square. Rows: " + std::to_string(rows) +
+                     " Cols: " + std::to_string(cols)));
+      }
+      Size n{rows};
+      if (n * n > std::numeric_limits<Id>::max()) {
+        throw std::invalid_argument(
+            buildLog("Matrix size is too large for the current type of Id."));
+      }
+      m_adjacency = SparseMatrix<bool>(n, n);
+      Id index{0};
+      while (!file.eof()) {
+        double value;
+        file >> value;
+        if (value < 0) {
+          throw std::invalid_argument(
+              buildLog("Adjacency matrix elements must be positive"));
+        }
+        if (value > 0) {
+          m_adjacency.insert(index, true);
+          const auto srcId{static_cast<Id>(index / n)};
+          const auto dstId{static_cast<Id>(index % n)};
+          if (!m_nodes.contains(srcId)) {
+            m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
+          }
+          if (!m_nodes.contains(dstId)) {
+            m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
+          }
+          m_streets.emplace(
+              index, std::make_unique<Street>(index, std::make_pair(srcId, dstId)));
+          assert(index == srcId * n + dstId);
+          if (!isAdj) {
+            m_streets[index]->setLength(value);
+          }
+        }
+        ++index;
+      }
+    }
+  }
+
+  void Graph::importCoordinates(const std::string& fileName) {
+    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
+    if (fileExt == "dsm") {
+      // first input number is the number of nodes
+      std::ifstream file{fileName};
+      if (!file.is_open()) {
+        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
+      }
+      Size n;
+      file >> n;
+      if (n < m_nodes.size()) {
+        throw std::invalid_argument(
+            buildLog("Number of node cordinates in file is too small."));
+      }
+      double lat, lon;
+      for (Size i{0}; i < n; ++i) {
+        file >> lat >> lon;
+        if (m_nodes.contains(i)) {
+          m_nodes[i]->setCoords(std::make_pair(lat, lon));
+        }
+      }
+    } else {
+      throw std::invalid_argument(buildLog("File extension not supported."));
+    }
+  }
+
+  void Graph::importOSMNodes(const std::string& fileName) {
+    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
+    if (fileExt == "csv") {
+      std::ifstream file{fileName};
+      if (!file.is_open()) {
+        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
+      }
+      std::string line;
+      std::getline(file, line);  // skip first line
+      Id nodeIndex{0};
+      while (!file.eof()) {
+        std::getline(file, line);
+        if (line.empty()) {
+          continue;
+        }
+        std::istringstream iss{line};
+        std::string id, lat, lon, highway;
+        // osmid;x;y;highway
+        std::getline(iss, id, ';');
+        std::getline(iss, lat, ';');
+        std::getline(iss, lon, ';');
+        std::getline(iss, highway, ';');
+        Id nodeId{static_cast<Id>(std::stoul(id))};
+        m_nodes.emplace(nodeIndex,
+                        std::make_unique<Node>(
+                            nodeIndex, std::make_pair(std::stod(lat), std::stod(lon))));
+        m_nodeMapping.emplace(std::make_pair(nodeId, nodeIndex));
+        ++nodeIndex;
+      }
+    } else {
+      throw std::invalid_argument(buildLog("File extension not supported"));
+    }
+  }
+
+  void Graph::importOSMEdges(const std::string& fileName) {
+    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
+    if (fileExt == "csv") {
+      std::ifstream file{fileName};
+      if (!file.is_open()) {
+        std::string errrorMsg{"Error at line " + std::to_string(__LINE__) + " in file " +
+                              __FILE__ + ": " + "File not found"};
+        throw std::invalid_argument(errrorMsg);
+      }
+      std::string line;
+      std::getline(file, line);  // skip first line
+      while (!file.eof()) {
+        std::getline(file, line);
+        if (line.empty()) {
+          continue;
+        }
+        std::istringstream iss{line};
+        std::string sourceId, targetId, length, oneway, highway, maxspeed, bridge;
+        // u;v;length;oneway;highway;maxspeed;bridge
+        std::getline(iss, sourceId, ';');
+        std::getline(iss, targetId, ';');
+        std::getline(iss, length, ';');
+        std::getline(iss, oneway, ';');
+        std::getline(iss, highway, ';');
+        std::getline(iss, maxspeed, ';');
+        std::getline(iss, bridge, ';');
+        try {
+          std::stod(maxspeed);
+        } catch (const std::invalid_argument& e) {
+          maxspeed = "30";
+        }
+        Id streetId = std::stoul(sourceId) + std::stoul(targetId) * m_nodes.size();
+        m_streets.emplace(streetId,
+                          std::make_unique<Street>(
+                              streetId,
+                              1,
+                              std::stod(maxspeed),
+                              std::stod(length),
+                              std::make_pair(m_nodeMapping[std::stoul(sourceId)],
+                                             m_nodeMapping[std::stoul(targetId)])));
+      }
+    } else {
+      std::string errrorMsg{"Error at line " + std::to_string(__LINE__) + " in file " +
+                            __FILE__ + ": " + "File extension not supported"};
+      throw std::invalid_argument(errrorMsg);
+    }
+  }
+
+  void Graph::exportMatrix(std::string path, bool isAdj) {
+    std::ofstream file{path};
+    if (!file.is_open()) {
+      throw std::invalid_argument(buildLog("Cannot open file: " + path));
+    }
+    if (isAdj) {
+      file << m_adjacency.getRowDim() << '\t' << m_adjacency.getColDim() << '\n';
+      for (const auto& [id, value] : m_adjacency) {
+        file << id << '\t' << value << '\n';
+      }
+    } else {
+      file << m_adjacency.getRowDim() << " " << m_adjacency.getColDim() << '\n';
+      for (const auto& [id, street] : m_streets) {
+        file << id << '\t' << street->length() << '\n';
+      }
+    }
+  }
+
+  void Graph::addNode(std::unique_ptr<NodeConcept> node) {
+    m_nodes.emplace(std::make_pair(node->id(), std::move(node)));
+  }
+
+  void Graph::addNode(const Node& node) {
+    m_nodes.emplace(std::make_pair(node.id(), std::make_unique<Node>(node)));
+  }
+
+  template <typename... Tn>
+    requires(is_node_v<std::remove_reference_t<Tn>> && ...)
+  void Graph::addNodes(Tn&&... nodes) {}
+
+  template <typename T1, typename... Tn>
+    requires is_node_v<std::remove_reference_t<T1>> &&
+             (is_node_v<std::remove_reference_t<Tn>> && ...)
+  void Graph::addNodes(T1&& node, Tn&&... nodes) {
+    addNode(std::forward<T1>(node));
+    addNodes(std::forward<Tn>(nodes)...);
+  }
+
+  void Graph::makeRoundabout(Id nodeId) {
+    if (!m_nodes.contains(nodeId)) {
+      throw std::invalid_argument(buildLog("Node does not exist."));
+    }
+    auto& pNode = m_nodes[nodeId];
+    pNode = std::make_unique<Roundabout>(*pNode);
+  }
+  void Graph::makeSpireStreet(Id streetId) {
+    if (!m_streets.contains(streetId)) {
+      throw std::invalid_argument(
+          buildLog(std::format("Street with id {} does not exist.", streetId)));
+    }
+    auto& pStreet = m_streets[streetId];
+    pStreet = std::make_unique<SpireStreet>(pStreet->id(), *pStreet);
+  }
+
+  void Graph::addStreet(std::shared_ptr<Street> street) {
+    if (m_streets.contains(street->id())) {
+      throw std::invalid_argument(
+          buildLog(std::format("Street with id {} already exists.", street->id())));
+    }
+    // emplace nodes
+    const auto srcId{street->nodePair().first};
+    const auto dstId{street->nodePair().second};
+    if (!m_nodes.contains(srcId)) {
+      m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
+    }
+    if (!m_nodes.contains(dstId)) {
+      m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
+    }
+    // emplace street
+    m_streets.emplace(street->id(), street.get());
+  }
+
+  void Graph::addStreet(const Street& street) {
+    if (m_streets.contains(street.id())) {
+      throw std::invalid_argument(
+          buildLog(std::format("Street with id {} already exists.", street.id())));
+    }
+    // emplace nodes
+    const auto srcId{street.nodePair().first};
+    const auto dstId{street.nodePair().second};
+    if (!m_nodes.contains(srcId)) {
+      m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
+    }
+    if (!m_nodes.contains(dstId)) {
+      m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
+    }
+    // emplace street
+    m_streets.emplace(std::make_pair(street.id(), std::make_unique<Street>(street)));
+  }
+
+  const std::unique_ptr<Street>* Graph::street(Id source, Id destination) const {
+    auto streetIt = std::find_if(m_streets.begin(),
+                                 m_streets.end(),
+                                 [source, destination](const auto& street) -> bool {
+                                   return street.second->nodePair().first == source &&
+                                          street.second->nodePair().second == destination;
+                                 });
+    if (streetIt == m_streets.end()) {
+      return nullptr;
+    }
+    Size n = m_nodes.size();
+    auto id1 = streetIt->first;
+    auto id2 = source * n + destination;
+    assert(id1 == id2);
+    if (id1 != id2) {
+      std::cout << "node size: " << n << std::endl;
+      std::cout << "Street id: " << id1 << std::endl;
+      std::cout << "Nodes: " << id2 << std::endl;
+    }
+    return &(streetIt->second);
+  }
+
+  const std::unique_ptr<Street>* Graph::oppositeStreet(Id streetId) const {
+    if (!m_streets.contains(streetId)) {
+      throw std::invalid_argument(
+          buildLog(std::format("Street with id {} does not exist: maybe it has changed "
+                               "id once called buildAdj.",
+                               streetId)));
+    }
+    const auto& nodePair = m_streets.at(streetId)->nodePair();
+    return this->street(nodePair.second, nodePair.first);
+  }
+
+  std::optional<DijkstraResult> Graph::shortestPath(const Node& source,
+                                                    const Node& destination) const {
+    return this->shortestPath(source.id(), destination.id());
+  }
+
+  std::optional<DijkstraResult> Graph::shortestPath(Id source, Id destination) const {
+    const Id sourceId{source};
+
+    std::unordered_set<Id> unvisitedNodes;
+    bool source_found{false};
+    bool dest_found{false};
+    std::for_each(m_nodes.begin(),
+                  m_nodes.end(),
+                  [&unvisitedNodes, &source_found, &dest_found, source, destination](
+                      const auto& node) -> void {
+                    if (!source_found && node.first == source) {
+                      source_found = true;
+                    }
+                    if (!dest_found && node.first == destination) {
+                      dest_found = true;
+                    }
+                    unvisitedNodes.emplace(node.first);
+                  });
+    if (!source_found || !dest_found) {
+      return std::nullopt;
+    }
+
+    const size_t n_nodes{m_nodes.size()};
+    auto adj{m_adjacency};
+
+    std::unordered_set<Id> visitedNodes;
+    std::vector<std::pair<Id, double>> dist(n_nodes);
+    std::for_each(dist.begin(), dist.end(), [count = 0](auto& element) mutable -> void {
+      element.first = count;
+      element.second = std::numeric_limits<double>::max();
+      ++count;
+    });
+    dist[source] = std::make_pair(source, 0.);
+
+    std::vector<std::pair<Id, double>> prev(n_nodes);
+    std::for_each(prev.begin(), prev.end(), [](auto& pair) -> void {
+      pair.first = std::numeric_limits<Id>::max();
+      pair.second = std::numeric_limits<double>::max();
+    });
+    prev[source].second = 0.;
+
+    while (unvisitedNodes.size() != 0) {
+      source = *std::min_element(unvisitedNodes.begin(),
+                                 unvisitedNodes.end(),
+                                 [&dist](const auto& a, const auto& b) -> bool {
+                                   return dist[a].second < dist[b].second;
+                                 });
+
+      unvisitedNodes.erase(source);
+      visitedNodes.emplace(source);
+
+      const auto& neighbors{adj.getRow(source)};
+      for (const auto& neighbour : neighbors) {
+        // if the node has already been visited, skip it
+        if (visitedNodes.find(neighbour.first) != visitedNodes.end()) {
+          continue;
+        }
+        double streetLength = (*(this->street(source, neighbour.first)))->length();
+        // if current path is shorter than the previous one, update the distance
+        if (streetLength + dist[source].second < dist[neighbour.first].second) {
+          dist[neighbour.first].second = streetLength + dist[source].second;
+          prev[neighbour.first] = std::make_pair(source, dist[neighbour.first].second);
+        }
+      }
+
+      adj.emptyColumn(source);
+    }
+
+    std::vector<Id> path{destination};
+    Id previous{destination};
+    while (true) {
+      previous = prev[previous].first;
+      if (previous == std::numeric_limits<Id>::max()) {
+        return std::nullopt;
+      }
+      path.push_back(previous);
+      if (previous == sourceId) {
+        break;
+      }
+    }
+
+    std::reverse(path.begin(), path.end());
+    return DijkstraResult(path, prev[destination].second);
+  }
+
+};  // namespace dsm

--- a/src/dsm/headers/Graph.cpp
+++ b/src/dsm/headers/Graph.cpp
@@ -317,19 +317,7 @@ namespace dsm {
   }
 
   void Graph::addNode(const Intersection& node) {
-    m_nodes.emplace(std::make_pair(node.id(), std::make_unique<Node>(node)));
-  }
-
-  template <typename... Tn>
-    requires(is_node_v<std::remove_reference_t<Tn>> && ...)
-  void Graph::addNodes(Tn&&... nodes) {}
-
-  template <typename T1, typename... Tn>
-    requires is_node_v<std::remove_reference_t<T1>> &&
-             (is_node_v<std::remove_reference_t<Tn>> && ...)
-  void Graph::addNodes(T1&& node, Tn&&... nodes) {
-    addNode(std::forward<T1>(node));
-    addNodes(std::forward<Tn>(nodes)...);
+    m_nodes.emplace(std::make_pair(node.id(), std::make_unique<Intersection>(node)));
   }
 
   void Graph::makeRoundabout(Id nodeId) {
@@ -417,8 +405,8 @@ namespace dsm {
     return this->street(nodePair.second, nodePair.first);
   }
 
-  std::optional<DijkstraResult> Graph::shortestPath(const Node& source,
-                                                    const Node& destination) const {
+  std::optional<DijkstraResult> Graph::shortestPath(const Intersection& source,
+                                                    const Intersection& destination) const {
     return this->shortestPath(source.id(), destination.id());
   }
 

--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -234,12 +234,12 @@ namespace dsm {
 
   template <typename... Tn>
     requires(is_node_v<std::remove_reference_t<Tn>> && ...)
-  void Graph<Id, Size>::addNodes(Tn&&... nodes) {}
+  void Graph::addNodes(Tn&&... nodes) {}
 
   template <typename T1, typename... Tn>
     requires is_node_v<std::remove_reference_t<T1>> &&
              (is_node_v<std::remove_reference_t<Tn>> && ...)
-  void Graph<Id, Size>::addNodes(T1&& node, Tn&&... nodes) {
+  void Graph::addNodes(T1&& node, Tn&&... nodes) {
     addNode(std::forward<T1>(node));
     addNodes(std::forward<Tn>(nodes)...);
   }

--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -51,21 +51,21 @@ namespace dsm {
     /// @brief Reassign the street ids using the max node id
     /// @details The street ids are reassigned using the max node id, i.e.
     /// newStreetId = srcId * n + dstId, where n is the max node id.
-    void m_reassignIds();
+    inline void m_reassignIds();
     /// @brief If every node has coordinates, set the street angles
     /// @details The street angles are set using the node's coordinates.
-    void m_setStreetAngles();
+    inline void m_setStreetAngles();
 
   public:
-    Graph();
+    inline Graph();
     /// @brief Construct a new Graph object
     /// @param adj An adjacency matrix made by a SparseMatrix representing the graph's adjacency matrix
-    Graph(const SparseMatrix<bool>& adj);
+    inline Graph(const SparseMatrix<bool>& adj);
     /// @brief Construct a new Graph object
     /// @param streetSet A map of streets representing the graph's streets
-    Graph(const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet);
+    inline Graph(const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet);
 
-    Graph(const Graph& other) {
+    inline Graph(const Graph& other) {
       std::for_each(other.m_nodes.begin(), other.m_nodes.end(), [this](const auto& pair) {
         this->m_nodes.emplace(pair.first, pair.second.get());
       });
@@ -78,7 +78,7 @@ namespace dsm {
       m_adjacency = other.m_adjacency;
     }
 
-    Graph& operator=(const Graph& other) {
+    inline Graph& operator=(const Graph& other) {
       std::for_each(other.m_nodes.begin(), other.m_nodes.end(), [this](const auto& pair) {
         this->m_nodes.insert_or_assign(pair.first,
                                        std::unique_ptr<NodeConcept>(pair.second.get()));
@@ -94,15 +94,15 @@ namespace dsm {
       return *this;
     }
 
-    Graph(Graph&&) = default;
-    Graph& operator=(Graph&&) = default;
+    inline Graph(Graph&&) = default;
+    inline Graph& operator=(Graph&&) = default;
 
     /// @brief Build the graph's adjacency matrix and computes max capacity
     /// @details The adjacency matrix is built using the graph's streets and nodes. N.B.: The street ids
     /// are reassigned using the max node id, i.e. newStreetId = srcId * n + dstId, where n is the max node id.
-    void buildAdj();
+    inline void buildAdj();
     /// @brief Build the graph's street angles using the node's coordinates
-    void buildStreetAngles();
+    inline void buildStreetAngles();
 
     /// @brief Import the graph's adjacency matrix from a file.
     /// If the file is not of a supported format, it will read the file as a matrix with the first two elements being
@@ -111,44 +111,44 @@ namespace dsm {
     /// @param isAdj A boolean value indicating if the file contains the adjacency matrix or the distance matrix.
     /// @throws std::invalid_argument if the file is not found or invalid
     /// The matrix format is deduced from the file extension. Currently only .dsm files are supported.
-    void importMatrix(const std::string& fileName, bool isAdj = true);
+    inline void importMatrix(const std::string& fileName, bool isAdj = true);
     /// @brief Import the graph's nodes from a file
     /// @param fileName The name of the file to import the nodes from.
     /// @throws std::invalid_argument if the file is not found, invalid or the format is not supported
     /// @details The file format is deduced from the file extension. Currently only .dsm files are supported.
     ///           The first input number is the number of nodes, followed by the coordinates of each node.
     ///           In the i-th row of the file, the (i - 1)-th node's coordinates are expected.
-    void importCoordinates(const std::string& fileName);
+    inline void importCoordinates(const std::string& fileName);
     /// @brief Import the graph's nodes from a file
     /// @param fileName The name of the file to import the nodes from.
     /// @throws std::invalid_argument if the file is not found, invalid or the format is not supported
-    void importOSMNodes(const std::string& fileName);
+    inline void importOSMNodes(const std::string& fileName);
     /// @brief Import the graph's streets from a file
     /// @param fileName The name of the file to import the streets from.
     /// @throws std::invalid_argument if the file is not found, invalid or the format is not supported
-    void importOSMEdges(const std::string& fileName);
+    inline void importOSMEdges(const std::string& fileName);
 
     /// @brief Export the graph's adjacency matrix to a file
     /// @param path The path to the file to export the adjacency matrix to.
     /// @param isAdj A boolean value indicating if the file contains the adjacency matrix or the distance matrix.
     /// @throws std::invalid_argument if the file is not found or invalid
-    void exportMatrix(std::string path = "./matrix.dsm", bool isAdj = true);
+    inline void exportMatrix(std::string path = "./matrix.dsm", bool isAdj = true);
 
     /// @brief Add a node to the graph
     /// @param node A std::unique_ptr to the node to add
-    void addNode(std::unique_ptr<NodeConcept> node);
+    inline void addNode(std::unique_ptr<NodeConcept> node);
     /// @brief Add a node to the graph
     /// @param node A reference to the node to add
-    void addNode(const Node& node);
+    inline void addNode(const Node& node);
 
     template <typename... Tn>
       requires(is_node_v<std::remove_reference_t<Tn>> && ...)
-    void addNodes(Tn&&... nodes);
+    inline void addNodes(Tn&&... nodes);
 
     template <typename T1, typename... Tn>
       requires is_node_v<std::remove_reference_t<T1>> &&
                (is_node_v<std::remove_reference_t<Tn>> && ...)
-    void addNodes(T1&& node, Tn&&... nodes);
+    inline void addNodes(T1&& node, Tn&&... nodes);
 
     /// @brief Convert an existing node to a traffic light
     /// @tparam Delay The type of the traffic light's delay
@@ -156,81 +156,81 @@ namespace dsm {
     /// @throws std::invalid_argument if the node does not exist
     template <typename Delay>
       requires(std::unsigned_integral<Delay>)
-    void makeTrafficLight(Id nodeId);
+    inline void makeTrafficLight(Id nodeId);
     /// @brief Convert an existing node into a roundabout
     /// @param nodeId The id of the node to convert to a roundabout
     /// @throws std::invalid_argument if the node does not exist
-    void makeRoundabout(Id nodeId);
+    inline void makeRoundabout(Id nodeId);
     /// @brief Convert an existing street into a spire street
     /// @param streetId The id of the street to convert to a spire street
     /// @throws std::invalid_argument if the street does not exist
-    void makeSpireStreet(Id streetId);
+    inline void makeSpireStreet(Id streetId);
 
     /// @brief Add a street to the graph
     /// @param street A std::shared_ptr to the street to add
-    void addStreet(std::shared_ptr<Street> street);
+    inline void addStreet(std::shared_ptr<Street> street);
     /// @brief Add a street to the graph
     /// @param street A reference to the street to add
-    void addStreet(const Street& street);
+    inline void addStreet(const Street& street);
 
     template <typename T1>
       requires is_street_v<std::remove_reference_t<T1>>
-    void addStreets(T1&& street);
+    inline void addStreets(T1&& street);
 
     template <typename T1, typename... Tn>
       requires is_street_v<std::remove_reference_t<T1>> &&
                (is_street_v<std::remove_reference_t<Tn>> && ...)
-    void addStreets(T1&& street, Tn&&... streets);
+    inline void addStreets(T1&& street, Tn&&... streets);
 
     /// @brief Get the graph's adjacency matrix
     /// @return A std::shared_ptr to the graph's adjacency matrix
-    const SparseMatrix<bool>& adjMatrix() const { return m_adjacency; }
+    inline const SparseMatrix<bool>& adjMatrix() const { return m_adjacency; }
     /// @brief Get the graph's node map
     /// @return A std::unordered_map containing the graph's nodes
-    const std::unordered_map<Id, std::unique_ptr<NodeConcept>>& nodeSet() const {
+    inline const std::unordered_map<Id, std::unique_ptr<NodeConcept>>& nodeSet() const {
       return m_nodes;
     }
     /// @brief Get the graph's node map
     /// @return A std::unordered_map containing the graph's nodes
-    std::unordered_map<Id, std::unique_ptr<NodeConcept>>& nodeSet() {
+    inline std::unordered_map<Id, std::unique_ptr<NodeConcept>>& nodeSet() {
       return m_nodes;
     }
     /// @brief Get the graph's street map
     /// @return A std::unordered_map containing the graph's streets
-    const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet() const {
+    inline const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet() const {
       return m_streets;
     }
     /// @brief Get the graph's street map
     /// @return A std::unordered_map containing the graph's streets
-    std::unordered_map<Id, std::unique_ptr<Street>>& streetSet() {
+    inline std::unordered_map<Id, std::unique_ptr<Street>>& streetSet() {
       return m_streets;
     }
     /// @brief Get a street from the graph
     /// @param source The source node
     /// @param destination The destination node
     /// @return A std::unique_ptr to the street if it exists, nullptr otherwise
-    const std::unique_ptr<Street>* street(Id source, Id destination) const;
+    inline const std::unique_ptr<Street>* street(Id source, Id destination) const;
     /// @brief Get the opposite street of a street in the graph
     /// @param streetId The id of the street
     /// @throws std::invalid_argument if the street does not exist
     /// @return A std::unique_ptr to the street if it exists, nullptr otherwise
-    const std::unique_ptr<Street>* oppositeStreet(Id streetId) const;
+    inline const std::unique_ptr<Street>* oppositeStreet(Id streetId) const;
 
     /// @brief Get the maximum agent capacity
     /// @return unsigned long long The maximum agent capacity of the graph
-    unsigned long long maxCapacity() const { return m_maxAgentCapacity; }
+    inline unsigned long long maxCapacity() const { return m_maxAgentCapacity; }
 
     /// @brief Get the shortest path between two nodes using dijkstra algorithm
     /// @param source The source node
     /// @param destination The destination node
     /// @return A DijkstraResult object containing the path and the distance
-    std::optional<DijkstraResult> shortestPath(
+    inline std::optional<DijkstraResult> shortestPath(
         const Node& source, const Node& destination) const;
     /// @brief Get the shortest path between two nodes using dijkstra algorithm
     /// @param source The source node id
     /// @param destination The destination node id
     /// @return A DijkstraResult object containing the path and the distance
-    std::optional<DijkstraResult> shortestPath(Id source, Id destination) const;
+    inline std::optional<DijkstraResult> shortestPath(Id source, Id destination) const;
   };
 
   Graph::Graph()

--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -57,13 +57,13 @@ namespace dsm {
     inline void m_setStreetAngles();
 
   public:
-    inline Graph();
+    Graph();
     /// @brief Construct a new Graph object
     /// @param adj An adjacency matrix made by a SparseMatrix representing the graph's adjacency matrix
-    inline Graph(const SparseMatrix<bool>& adj);
+    Graph(const SparseMatrix<bool>& adj);
     /// @brief Construct a new Graph object
     /// @param streetSet A map of streets representing the graph's streets
-    inline Graph(const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet);
+    Graph(const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet);
 
     inline Graph(const Graph& other) {
       std::for_each(other.m_nodes.begin(), other.m_nodes.end(), [this](const auto& pair) {
@@ -71,8 +71,7 @@ namespace dsm {
       });
       std::for_each(
           other.m_streets.begin(), other.m_streets.end(), [this](const auto& pair) {
-            this->m_streets.emplace(pair.first,
-                                    pair.second.get());
+            this->m_streets.emplace(pair.first, pair.second.get());
           });
       m_nodeMapping = other.m_nodeMapping;
       m_adjacency = other.m_adjacency;
@@ -85,8 +84,8 @@ namespace dsm {
       });
       std::for_each(
           other.m_streets.begin(), other.m_streets.end(), [this](const auto& pair) {
-            this->m_streets.insert_or_assign(
-                pair.first, std::make_unique<Street>(*pair.second));
+            this->m_streets.insert_or_assign(pair.first,
+                                             std::make_unique<Street>(*pair.second));
           });
       m_nodeMapping = other.m_nodeMapping;
       m_adjacency = other.m_adjacency;
@@ -100,9 +99,9 @@ namespace dsm {
     /// @brief Build the graph's adjacency matrix and computes max capacity
     /// @details The adjacency matrix is built using the graph's streets and nodes. N.B.: The street ids
     /// are reassigned using the max node id, i.e. newStreetId = srcId * n + dstId, where n is the max node id.
-    inline void buildAdj();
+    void buildAdj();
     /// @brief Build the graph's street angles using the node's coordinates
-    inline void buildStreetAngles();
+    void buildStreetAngles();
 
     /// @brief Import the graph's adjacency matrix from a file.
     /// If the file is not of a supported format, it will read the file as a matrix with the first two elements being
@@ -111,44 +110,44 @@ namespace dsm {
     /// @param isAdj A boolean value indicating if the file contains the adjacency matrix or the distance matrix.
     /// @throws std::invalid_argument if the file is not found or invalid
     /// The matrix format is deduced from the file extension. Currently only .dsm files are supported.
-    inline void importMatrix(const std::string& fileName, bool isAdj = true);
+    void importMatrix(const std::string& fileName, bool isAdj = true);
     /// @brief Import the graph's nodes from a file
     /// @param fileName The name of the file to import the nodes from.
     /// @throws std::invalid_argument if the file is not found, invalid or the format is not supported
     /// @details The file format is deduced from the file extension. Currently only .dsm files are supported.
     ///           The first input number is the number of nodes, followed by the coordinates of each node.
     ///           In the i-th row of the file, the (i - 1)-th node's coordinates are expected.
-    inline void importCoordinates(const std::string& fileName);
+    void importCoordinates(const std::string& fileName);
     /// @brief Import the graph's nodes from a file
     /// @param fileName The name of the file to import the nodes from.
     /// @throws std::invalid_argument if the file is not found, invalid or the format is not supported
-    inline void importOSMNodes(const std::string& fileName);
+    void importOSMNodes(const std::string& fileName);
     /// @brief Import the graph's streets from a file
     /// @param fileName The name of the file to import the streets from.
     /// @throws std::invalid_argument if the file is not found, invalid or the format is not supported
-    inline void importOSMEdges(const std::string& fileName);
+    void importOSMEdges(const std::string& fileName);
 
     /// @brief Export the graph's adjacency matrix to a file
     /// @param path The path to the file to export the adjacency matrix to.
     /// @param isAdj A boolean value indicating if the file contains the adjacency matrix or the distance matrix.
     /// @throws std::invalid_argument if the file is not found or invalid
-    inline void exportMatrix(std::string path = "./matrix.dsm", bool isAdj = true);
+    void exportMatrix(std::string path = "./matrix.dsm", bool isAdj = true);
 
     /// @brief Add a node to the graph
     /// @param node A std::unique_ptr to the node to add
-    inline void addNode(std::unique_ptr<NodeConcept> node);
+    void addNode(std::unique_ptr<NodeConcept> node);
     /// @brief Add a node to the graph
     /// @param node A reference to the node to add
-    inline void addNode(const Node& node);
+    void addNode(const Node& node);
 
     template <typename... Tn>
       requires(is_node_v<std::remove_reference_t<Tn>> && ...)
-    inline void addNodes(Tn&&... nodes);
+    void addNodes(Tn&&... nodes);
 
     template <typename T1, typename... Tn>
       requires is_node_v<std::remove_reference_t<T1>> &&
                (is_node_v<std::remove_reference_t<Tn>> && ...)
-    inline void addNodes(T1&& node, Tn&&... nodes);
+    void addNodes(T1&& node, Tn&&... nodes);
 
     /// @brief Convert an existing node to a traffic light
     /// @tparam Delay The type of the traffic light's delay
@@ -156,31 +155,31 @@ namespace dsm {
     /// @throws std::invalid_argument if the node does not exist
     template <typename Delay>
       requires(std::unsigned_integral<Delay>)
-    inline void makeTrafficLight(Id nodeId);
+    void makeTrafficLight(Id nodeId);
     /// @brief Convert an existing node into a roundabout
     /// @param nodeId The id of the node to convert to a roundabout
     /// @throws std::invalid_argument if the node does not exist
-    inline void makeRoundabout(Id nodeId);
+    void makeRoundabout(Id nodeId);
     /// @brief Convert an existing street into a spire street
     /// @param streetId The id of the street to convert to a spire street
     /// @throws std::invalid_argument if the street does not exist
-    inline void makeSpireStreet(Id streetId);
+    void makeSpireStreet(Id streetId);
 
     /// @brief Add a street to the graph
     /// @param street A std::shared_ptr to the street to add
-    inline void addStreet(std::shared_ptr<Street> street);
+    void addStreet(std::shared_ptr<Street> street);
     /// @brief Add a street to the graph
     /// @param street A reference to the street to add
-    inline void addStreet(const Street& street);
+    void addStreet(const Street& street);
 
     template <typename T1>
       requires is_street_v<std::remove_reference_t<T1>>
-    inline void addStreets(T1&& street);
+    void addStreets(T1&& street);
 
     template <typename T1, typename... Tn>
       requires is_street_v<std::remove_reference_t<T1>> &&
                (is_street_v<std::remove_reference_t<Tn>> && ...)
-    inline void addStreets(T1&& street, Tn&&... streets);
+    void addStreets(T1&& street, Tn&&... streets);
 
     /// @brief Get the graph's adjacency matrix
     /// @return A std::shared_ptr to the graph's adjacency matrix
@@ -209,425 +208,29 @@ namespace dsm {
     /// @param source The source node
     /// @param destination The destination node
     /// @return A std::unique_ptr to the street if it exists, nullptr otherwise
-    inline const std::unique_ptr<Street>* street(Id source, Id destination) const;
+    const std::unique_ptr<Street>* street(Id source, Id destination) const;
     /// @brief Get the opposite street of a street in the graph
     /// @param streetId The id of the street
     /// @throws std::invalid_argument if the street does not exist
     /// @return A std::unique_ptr to the street if it exists, nullptr otherwise
-    inline const std::unique_ptr<Street>* oppositeStreet(Id streetId) const;
+    const std::unique_ptr<Street>* oppositeStreet(Id streetId) const;
 
     /// @brief Get the maximum agent capacity
     /// @return unsigned long long The maximum agent capacity of the graph
-    inline unsigned long long maxCapacity() const { return m_maxAgentCapacity; }
+    unsigned long long maxCapacity() const { return m_maxAgentCapacity; }
 
     /// @brief Get the shortest path between two nodes using dijkstra algorithm
     /// @param source The source node
     /// @param destination The destination node
     /// @return A DijkstraResult object containing the path and the distance
-    inline std::optional<DijkstraResult> shortestPath(
-        const Node& source, const Node& destination) const;
+    std::optional<DijkstraResult> shortestPath(const Node& source,
+                                               const Node& destination) const;
     /// @brief Get the shortest path between two nodes using dijkstra algorithm
     /// @param source The source node id
     /// @param destination The destination node id
     /// @return A DijkstraResult object containing the path and the distance
-    inline std::optional<DijkstraResult> shortestPath(Id source, Id destination) const;
+    std::optional<DijkstraResult> shortestPath(Id source, Id destination) const;
   };
-
-  Graph::Graph()
-      : m_adjacency{SparseMatrix<bool>()},
-        m_maxAgentCapacity{std::numeric_limits<unsigned long long>::max()} {}
-
-  Graph::Graph(const SparseMatrix<bool>& adj)
-      : m_adjacency{adj},
-        m_maxAgentCapacity{std::numeric_limits<unsigned long long>::max()} {
-    assert(adj.getRowDim() == adj.getColDim());
-    auto n{static_cast<Size>(adj.getRowDim())};
-    for (const auto& [id, value] : adj) {
-      const auto srcId{static_cast<Id>(id / n)};
-      const auto dstId{static_cast<Id>(id % n)};
-      if (!m_nodes.contains(srcId)) {
-        m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
-      }
-      if (!m_nodes.contains(dstId)) {
-        m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
-      }
-      m_streets.emplace(
-          id, std::make_unique<Street>(id, std::make_pair(srcId, dstId)));
-    }
-  }
-
-  Graph::Graph(
-      const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet)
-      : m_adjacency{SparseMatrix<bool>()} {
-    for (auto& street : streetSet) {
-      m_streets.emplace(street.second->id(), street.second.get());
-
-      Id node1 = street.second->nodePair().first;
-      Id node2 = street.second->nodePair().second;
-      m_nodes.emplace(node1, std::make_unique<Node>(node1));
-      m_nodes.emplace(node2, std::make_unique<Node>(node2));
-    }
-
-    buildAdj();
-  }
-
-  void Graph::m_reassignIds() {
-    // not sure about this, might need a bit more work
-    const auto oldStreetSet{std::move(m_streets)};
-    m_streets.clear();
-    const auto n{static_cast<Size>(m_nodes.size())};
-    std::unordered_map<Id, Id> newStreetIds;
-    for (const auto& [streetId, street] : oldStreetSet) {
-      const auto srcId{street->nodePair().first};
-      const auto dstId{street->nodePair().second};
-      const auto newStreetId{static_cast<Id>(srcId * n + dstId)};
-      if (m_streets.contains(newStreetId)) {
-        throw std::invalid_argument(buildLog("Street with same id already exists."));
-      }
-      auto newStreet = Street(newStreetId, *street);
-      m_streets.emplace(newStreetId, std::make_unique<Street>(newStreet));
-      newStreetIds.emplace(streetId, newStreetId);
-    }
-    for (const auto& [nodeId, node] : m_nodes) {
-      // This is probably not the best way to do this
-      if (node->isIntersection()) {
-        auto& intersection = dynamic_cast<Node&>(*node);
-        const auto& oldStreetPriorities{intersection.streetPriorities()};
-        std::set<Id> newStreetPriorities;
-        for (const auto streetId : oldStreetPriorities) {
-          newStreetPriorities.emplace(newStreetIds[streetId]);
-        }
-        intersection.setStreetPriorities(newStreetPriorities);
-      }
-    }
-  }
-
-  void Graph::m_setStreetAngles() {
-    for (const auto& [streetId, street] : m_streets) {
-      const auto& srcNode{m_nodes[street->nodePair().first]};
-      const auto& dstNode{m_nodes[street->nodePair().second]};
-      if (srcNode->coords().has_value() && dstNode->coords().has_value()) {
-        street->setAngle(srcNode->coords().value(), dstNode->coords().value());
-      }
-    }
-  }
-
-  void Graph::buildAdj() {
-    // find max values in streets node pairs
-    m_maxAgentCapacity = 0;
-    const auto maxNode{static_cast<Id>(m_nodes.size())};
-    m_adjacency.reshape(maxNode, maxNode);
-    for (const auto& [streetId, street] : m_streets) {
-      m_maxAgentCapacity += street->capacity();
-      m_adjacency.insert(street->nodePair().first, street->nodePair().second, true);
-    }
-    this->m_reassignIds();
-    this->m_setStreetAngles();
-  }
-
-  void Graph::buildStreetAngles() {
-    for (const auto& street : m_streets) {
-      const auto& node1{m_nodes[street.second->nodePair().first]};
-      const auto& node2{m_nodes[street.second->nodePair().second]};
-      street.second->setAngle(node1->coords().value(), node2->coords().value());
-    }
-  }
-
-  void Graph::importMatrix(const std::string& fileName, bool isAdj) {
-    // check the file extension
-    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
-    if (fileExt == "dsm") {
-      std::ifstream file{fileName};
-      if (!file.is_open()) {
-        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
-      }
-      Size rows, cols;
-      file >> rows >> cols;
-      if (rows != cols) {
-        throw std::invalid_argument(buildLog("Adjacency matrix must be square"));
-      }
-      Size n{rows};
-      m_adjacency = SparseMatrix<bool>(n, n);
-      // each line has 2 elements
-      while (!file.eof()) {
-        Id index;
-        double val;
-        file >> index >> val;
-        m_adjacency.insert(index, val);
-        const auto srcId{static_cast<Id>(index / n)};
-        const auto dstId{static_cast<Id>(index % n)};
-        if (!m_nodes.contains(srcId)) {
-          m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
-        }
-        if (!m_nodes.contains(dstId)) {
-          m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
-        }
-        m_streets.emplace(
-            index,
-            std::make_unique<Street>(index, std::make_pair(srcId, dstId)));
-        assert(index == srcId * n + dstId);
-        if (!isAdj) {
-          m_streets[index]->setLength(val);
-        }
-      }
-    } else {
-      // default case: read the file as a matrix with the first two elements being the number of rows and columns and
-      // the following elements being the matrix elements
-      std::ifstream file{fileName};
-      if (!file.is_open()) {
-        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
-      }
-      Size rows, cols;
-      file >> rows >> cols;
-      if (rows != cols) {
-        throw std::invalid_argument(
-            buildLog("Adjacency matrix must be square. Rows: " + std::to_string(rows) +
-                     " Cols: " + std::to_string(cols)));
-      }
-      Size n{rows};
-      if (n * n > std::numeric_limits<Id>::max()) {
-        throw std::invalid_argument(
-            buildLog("Matrix size is too large for the current type of Id."));
-      }
-      m_adjacency = SparseMatrix<bool>(n, n);
-      Id index{0};
-      while (!file.eof()) {
-        double value;
-        file >> value;
-        if (value < 0) {
-          throw std::invalid_argument(
-              buildLog("Adjacency matrix elements must be positive"));
-        }
-        if (value > 0) {
-          m_adjacency.insert(index, true);
-          const auto srcId{static_cast<Id>(index / n)};
-          const auto dstId{static_cast<Id>(index % n)};
-          if (!m_nodes.contains(srcId)) {
-            m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
-          }
-          if (!m_nodes.contains(dstId)) {
-            m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
-          }
-          m_streets.emplace(
-              index,
-              std::make_unique<Street>(index, std::make_pair(srcId, dstId)));
-          assert(index == srcId * n + dstId);
-          if (!isAdj) {
-            m_streets[index]->setLength(value);
-          }
-        }
-        ++index;
-      }
-    }
-  }
-
-  void Graph::importCoordinates(const std::string& fileName) {
-    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
-    if (fileExt == "dsm") {
-      // first input number is the number of nodes
-      std::ifstream file{fileName};
-      if (!file.is_open()) {
-        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
-      }
-      Size n;
-      file >> n;
-      if (n < m_nodes.size()) {
-        throw std::invalid_argument(
-            buildLog("Number of node cordinates in file is too small."));
-      }
-      double lat, lon;
-      for (Size i{0}; i < n; ++i) {
-        file >> lat >> lon;
-        if (m_nodes.contains(i)) {
-          m_nodes[i]->setCoords(std::make_pair(lat, lon));
-        }
-      }
-    } else {
-      throw std::invalid_argument(buildLog("File extension not supported."));
-    }
-  }
-
-  void Graph::importOSMNodes(const std::string& fileName) {
-    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
-    if (fileExt == "csv") {
-      std::ifstream file{fileName};
-      if (!file.is_open()) {
-        throw std::invalid_argument(buildLog("Cannot find file: " + fileName));
-      }
-      std::string line;
-      std::getline(file, line);  // skip first line
-      Id nodeIndex{0};
-      while (!file.eof()) {
-        std::getline(file, line);
-        if (line.empty()) {
-          continue;
-        }
-        std::istringstream iss{line};
-        std::string id, lat, lon, highway;
-        // osmid;x;y;highway
-        std::getline(iss, id, ';');
-        std::getline(iss, lat, ';');
-        std::getline(iss, lon, ';');
-        std::getline(iss, highway, ';');
-        Id nodeId{static_cast<Id>(std::stoul(id))};
-        m_nodes.emplace(nodeIndex,
-                        std::make_unique<Node>(
-                            nodeIndex, std::make_pair(std::stod(lat), std::stod(lon))));
-        m_nodeMapping.emplace(std::make_pair(nodeId, nodeIndex));
-        ++nodeIndex;
-      }
-    } else {
-      throw std::invalid_argument(buildLog("File extension not supported"));
-    }
-  }
-
-  void Graph::importOSMEdges(const std::string& fileName) {
-    std::string fileExt = fileName.substr(fileName.find_last_of(".") + 1);
-    if (fileExt == "csv") {
-      std::ifstream file{fileName};
-      if (!file.is_open()) {
-        std::string errrorMsg{"Error at line " + std::to_string(__LINE__) + " in file " +
-                              __FILE__ + ": " + "File not found"};
-        throw std::invalid_argument(errrorMsg);
-      }
-      std::string line;
-      std::getline(file, line);  // skip first line
-      while (!file.eof()) {
-        std::getline(file, line);
-        if (line.empty()) {
-          continue;
-        }
-        std::istringstream iss{line};
-        std::string sourceId, targetId, length, oneway, highway, maxspeed, bridge;
-        // u;v;length;oneway;highway;maxspeed;bridge
-        std::getline(iss, sourceId, ';');
-        std::getline(iss, targetId, ';');
-        std::getline(iss, length, ';');
-        std::getline(iss, oneway, ';');
-        std::getline(iss, highway, ';');
-        std::getline(iss, maxspeed, ';');
-        std::getline(iss, bridge, ';');
-        try {
-          std::stod(maxspeed);
-        } catch (const std::invalid_argument& e) {
-          maxspeed = "30";
-        }
-        Id streetId = std::stoul(sourceId) + std::stoul(targetId) * m_nodes.size();
-        m_streets.emplace(streetId,
-                          std::make_unique<Street>(
-                              streetId,
-                              1,
-                              std::stod(maxspeed),
-                              std::stod(length),
-                              std::make_pair(m_nodeMapping[std::stoul(sourceId)],
-                                             m_nodeMapping[std::stoul(targetId)])));
-      }
-    } else {
-      std::string errrorMsg{"Error at line " + std::to_string(__LINE__) + " in file " +
-                            __FILE__ + ": " + "File extension not supported"};
-      throw std::invalid_argument(errrorMsg);
-    }
-  }
-
-  void Graph::exportMatrix(std::string path, bool isAdj) {
-    std::ofstream file{path};
-    if (!file.is_open()) {
-      throw std::invalid_argument(buildLog("Cannot open file: " + path));
-    }
-    if (isAdj) {
-      file << m_adjacency.getRowDim() << '\t' << m_adjacency.getColDim() << '\n';
-      for (const auto& [id, value] : m_adjacency) {
-        file << id << '\t' << value << '\n';
-      }
-    } else {
-      file << m_adjacency.getRowDim() << " " << m_adjacency.getColDim() << '\n';
-      for (const auto& [id, street] : m_streets) {
-        file << id << '\t' << street->length() << '\n';
-      }
-    }
-  }
-
-  void Graph::addNode(std::unique_ptr<NodeConcept> node) {
-    m_nodes.emplace(std::make_pair(node->id(), std::move(node)));
-  }
-
-  void Graph::addNode(const Node& node) {
-    m_nodes.emplace(std::make_pair(node.id(), std::make_unique<Node>(node)));
-  }
-
-  template <typename... Tn>
-    requires(is_node_v<std::remove_reference_t<Tn>> && ...)
-  void Graph::addNodes(Tn&&... nodes) {}
-
-  template <typename T1, typename... Tn>
-    requires is_node_v<std::remove_reference_t<T1>> &&
-             (is_node_v<std::remove_reference_t<Tn>> && ...)
-  void Graph::addNodes(T1&& node, Tn&&... nodes) {
-    addNode(std::forward<T1>(node));
-    addNodes(std::forward<Tn>(nodes)...);
-  }
-
-  template <typename Delay>
-    requires(std::unsigned_integral<Delay>)
-  void Graph::makeTrafficLight(Id nodeId) {
-    if (!m_nodes.contains(nodeId)) {
-      throw std::invalid_argument(buildLog("Node does not exist."));
-    }
-    auto& pNode = m_nodes[nodeId];
-    pNode = std::make_unique<TrafficLight<Delay>>(*pNode);
-  }
-  void Graph::makeRoundabout(Id nodeId) {
-    if (!m_nodes.contains(nodeId)) {
-      throw std::invalid_argument(buildLog("Node does not exist."));
-    }
-    auto& pNode = m_nodes[nodeId];
-    pNode = std::make_unique<Roundabout>(*pNode);
-  }
-  void Graph::makeSpireStreet(Id streetId) {
-    if (!m_streets.contains(streetId)) {
-      throw std::invalid_argument(
-          buildLog(std::format("Street with id {} does not exist.", streetId)));
-    }
-    auto& pStreet = m_streets[streetId];
-    pStreet = std::make_unique<SpireStreet>(pStreet->id(), *pStreet);
-  }
-
-  void Graph::addStreet(std::shared_ptr<Street> street) {
-    if (m_streets.contains(street->id())) {
-      throw std::invalid_argument(
-          buildLog(std::format("Street with id {} already exists.", street->id())));
-    }
-    // emplace nodes
-    const auto srcId{street->nodePair().first};
-    const auto dstId{street->nodePair().second};
-    if (!m_nodes.contains(srcId)) {
-      m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
-    }
-    if (!m_nodes.contains(dstId)) {
-      m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
-    }
-    // emplace street
-    m_streets.emplace(street->id(), street.get());
-  }
-
-  void Graph::addStreet(const Street& street) {
-    if (m_streets.contains(street.id())) {
-      throw std::invalid_argument(
-          buildLog(std::format("Street with id {} already exists.", street.id())));
-    }
-    // emplace nodes
-    const auto srcId{street.nodePair().first};
-    const auto dstId{street.nodePair().second};
-    if (!m_nodes.contains(srcId)) {
-      m_nodes.emplace(srcId, std::make_unique<Node>(srcId));
-    }
-    if (!m_nodes.contains(dstId)) {
-      m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
-    }
-    // emplace street
-    m_streets.emplace(
-        std::make_pair(street.id(), std::make_unique<Street>(street)));
-  }
 
   template <typename T1>
     requires is_street_v<std::remove_reference_t<T1>>
@@ -646,8 +249,7 @@ namespace dsm {
       m_nodes.emplace(dstId, std::make_unique<Node>(dstId));
     }
     // emplace street
-    m_streets.emplace(
-        std::make_pair(street.id(), std::make_unique<Street>(street)));
+    m_streets.emplace(std::make_pair(street.id(), std::make_unique<Street>(street)));
   }
 
   template <typename T1, typename... Tn>
@@ -658,129 +260,14 @@ namespace dsm {
     addStreets(std::forward<Tn>(streets)...);
   }
 
-  const std::unique_ptr<Street>* Graph::street(Id source,
-                                                                   Id destination) const {
-    auto streetIt = std::find_if(m_streets.begin(),
-                                 m_streets.end(),
-                                 [source, destination](const auto& street) -> bool {
-                                   return street.second->nodePair().first == source &&
-                                          street.second->nodePair().second == destination;
-                                 });
-    if (streetIt == m_streets.end()) {
-      return nullptr;
+  template <typename Delay>
+    requires(std::unsigned_integral<Delay>)
+  void Graph::makeTrafficLight(Id nodeId) {
+    if (!m_nodes.contains(nodeId)) {
+      throw std::invalid_argument(buildLog("Node does not exist."));
     }
-    Size n = m_nodes.size();
-    auto id1 = streetIt->first;
-    auto id2 = source * n + destination;
-    assert(id1 == id2);
-    if (id1 != id2) {
-      std::cout << "node size: " << n << std::endl;
-      std::cout << "Street id: " << id1 << std::endl;
-      std::cout << "Nodes: " << id2 << std::endl;
-    }
-    return &(streetIt->second);
+    auto& pNode = m_nodes[nodeId];
+    pNode = std::make_unique<TrafficLight<Delay>>(*pNode);
   }
 
-  const std::unique_ptr<Street>* Graph::oppositeStreet(
-      Id streetId) const {
-    if (!m_streets.contains(streetId)) {
-      throw std::invalid_argument(
-          buildLog(std::format("Street with id {} does not exist: maybe it has changed "
-                               "id once called buildAdj.",
-                               streetId)));
-    }
-    const auto& nodePair = m_streets.at(streetId)->nodePair();
-    return this->street(nodePair.second, nodePair.first);
-  }
-
-  std::optional<DijkstraResult> Graph::shortestPath(
-      const Node& source, const Node& destination) const {
-    return this->shortestPath(source.id(), destination.id());
-  }
-
-  std::optional<DijkstraResult> Graph::shortestPath(Id source,
-                                                                  Id destination) const {
-    const Id sourceId{source};
-
-    std::unordered_set<Id> unvisitedNodes;
-    bool source_found{false};
-    bool dest_found{false};
-    std::for_each(m_nodes.begin(),
-                  m_nodes.end(),
-                  [&unvisitedNodes, &source_found, &dest_found, source, destination](
-                      const auto& node) -> void {
-                    if (!source_found && node.first == source) {
-                      source_found = true;
-                    }
-                    if (!dest_found && node.first == destination) {
-                      dest_found = true;
-                    }
-                    unvisitedNodes.emplace(node.first);
-                  });
-    if (!source_found || !dest_found) {
-      return std::nullopt;
-    }
-
-    const size_t n_nodes{m_nodes.size()};
-    auto adj{m_adjacency};
-
-    std::unordered_set<Id> visitedNodes;
-    std::vector<std::pair<Id, double>> dist(n_nodes);
-    std::for_each(dist.begin(), dist.end(), [count = 0](auto& element) mutable -> void {
-      element.first = count;
-      element.second = std::numeric_limits<double>::max();
-      ++count;
-    });
-    dist[source] = std::make_pair(source, 0.);
-
-    std::vector<std::pair<Id, double>> prev(n_nodes);
-    std::for_each(prev.begin(), prev.end(), [](auto& pair) -> void {
-      pair.first = std::numeric_limits<Id>::max();
-      pair.second = std::numeric_limits<double>::max();
-    });
-    prev[source].second = 0.;
-
-    while (unvisitedNodes.size() != 0) {
-      source = *std::min_element(unvisitedNodes.begin(),
-                                 unvisitedNodes.end(),
-                                 [&dist](const auto& a, const auto& b) -> bool {
-                                   return dist[a].second < dist[b].second;
-                                 });
-
-      unvisitedNodes.erase(source);
-      visitedNodes.emplace(source);
-
-      const auto& neighbors{adj.getRow(source)};
-      for (const auto& neighbour : neighbors) {
-        // if the node has already been visited, skip it
-        if (visitedNodes.find(neighbour.first) != visitedNodes.end()) {
-          continue;
-        }
-        double streetLength = (*(this->street(source, neighbour.first)))->length();
-        // if current path is shorter than the previous one, update the distance
-        if (streetLength + dist[source].second < dist[neighbour.first].second) {
-          dist[neighbour.first].second = streetLength + dist[source].second;
-          prev[neighbour.first] = std::make_pair(source, dist[neighbour.first].second);
-        }
-      }
-
-      adj.emptyColumn(source);
-    }
-
-    std::vector<Id> path{destination};
-    Id previous{destination};
-    while (true) {
-      previous = prev[previous].first;
-      if (previous == std::numeric_limits<Id>::max()) {
-        return std::nullopt;
-      }
-      path.push_back(previous);
-      if (previous == sourceId) {
-        break;
-      }
-    }
-
-    std::reverse(path.begin(), path.end());
-    return DijkstraResult(path, prev[destination].second);
-  }
 };  // namespace dsm

--- a/src/dsm/headers/Graph.hpp
+++ b/src/dsm/headers/Graph.hpp
@@ -191,9 +191,7 @@ namespace dsm {
     }
     /// @brief Get the graph's node map
     /// @return A std::unordered_map containing the graph's nodes
-    inline std::unordered_map<Id, std::unique_ptr<Node>>& nodeSet() {
-      return m_nodes;
-    }
+    inline std::unordered_map<Id, std::unique_ptr<Node>>& nodeSet() { return m_nodes; }
     /// @brief Get the graph's street map
     /// @return A std::unordered_map containing the graph's streets
     inline const std::unordered_map<Id, std::unique_ptr<Street>>& streetSet() const {

--- a/src/dsm/headers/Itinerary.cpp
+++ b/src/dsm/headers/Itinerary.cpp
@@ -1,0 +1,33 @@
+
+#include "Itinerary.hpp"
+
+namespace dsm {
+  Itinerary::Itinerary(Id id, Id destination) : m_id{id}, m_destination{destination} {}
+
+  Itinerary::Itinerary(Id id, Id destination, SparseMatrix<bool> path)
+      : m_id{id}, m_path{std::move(path)}, m_destination{destination} {}
+
+  void Itinerary::setDestination(Id destination) {
+    m_destination = destination;
+    this->m_path.clear();
+  }
+
+  void Itinerary::setPath(SparseMatrix<bool> path) {
+    if (path.getRowDim() != path.getColDim()) {
+      throw std::invalid_argument(buildLog(
+          std::format("The path's row ({}) and column ({}) dimensions must be equal.",
+                      path.getRowDim(),
+                      path.getColDim())));
+    }
+    if (path.getRowDim() < m_destination) {
+      throw std::invalid_argument(
+          buildLog(std::format("The path's row ({}) and column ({}) dimensions must be "
+                               "greater than the itinerary's destination ({}).",
+                               path.getRowDim(),
+                               path.getColDim(),
+                               m_destination)));
+    }
+    m_path = std::move(path);
+  }
+
+};  // namespace dsm

--- a/src/dsm/headers/Itinerary.hpp
+++ b/src/dsm/headers/Itinerary.hpp
@@ -28,58 +28,29 @@ namespace dsm {
   public:
     /// @brief Construct a new Itinerary object
     /// @param destination The itinerary's destination
-    inline Itinerary(Id id, Id destination);
+    Itinerary(Id id, Id destination);
     /// @brief Construct a new Itinerary object
     /// @param destination The itinerary's destination
     /// @param path An adjacency matrix made by a SparseMatrix representing the itinerary's path
-    inline Itinerary(Id id, Id destination, SparseMatrix<bool> path);
+    Itinerary(Id id, Id destination, SparseMatrix<bool> path);
 
     /// @brief Set the itinerary's destination
     /// @param destination The itinerary's destination
-    inline void setDestination(Id destination);
+    void setDestination(Id destination);
     /// @brief Set the itinerary's path
     /// @param path An adjacency matrix made by a SparseMatrix representing the itinerary's path
     /// @throw std::invalid_argument, if the itinerary's source or destination is not in the path's
-    inline void setPath(SparseMatrix<bool> path);
+    void setPath(SparseMatrix<bool> path);
 
     /// @brief Get the itinerary's id
     /// @return Id, The itinerary's id
-    inline Id id() const { return m_id; }
+    Id id() const { return m_id; }
     /// @brief Get the itinerary's destination
     /// @return Id, The itinerary's destination
-    inline Id destination() const { return m_destination; }
+    Id destination() const { return m_destination; }
     /// @brief Get the itinerary's path
     /// @return SparseMatrix<Id, bool>, An adjacency matrix made by a SparseMatrix representing the
     /// itinerary's path
-    inline const SparseMatrix<bool>& path() const { return m_path; }
+    const SparseMatrix<bool>& path() const { return m_path; }
   };
-
-  Itinerary::Itinerary(Id id, Id destination)
-      : m_id{id}, m_destination{destination} {}
-
-  Itinerary::Itinerary(Id id, Id destination, SparseMatrix<bool> path)
-      : m_id{id}, m_path{std::move(path)}, m_destination{destination} {}
-
-  void Itinerary::setDestination(Id destination) {
-    m_destination = destination;
-    this->m_path.clear();
-  }
-
-  void Itinerary::setPath(SparseMatrix<bool> path) {
-    if (path.getRowDim() != path.getColDim()) {
-      throw std::invalid_argument(buildLog(
-          std::format("The path's row ({}) and column ({}) dimensions must be equal.",
-                      path.getRowDim(),
-                      path.getColDim())));
-    }
-    if (path.getRowDim() < m_destination) {
-      throw std::invalid_argument(
-          buildLog(std::format("The path's row ({}) and column ({}) dimensions must be "
-                               "greater than the itinerary's destination ({}).",
-                               path.getRowDim(),
-                               path.getColDim(),
-                               m_destination)));
-    }
-    m_path = std::move(path);
-  }
 };  // namespace dsm

--- a/src/dsm/headers/Itinerary.hpp
+++ b/src/dsm/headers/Itinerary.hpp
@@ -28,30 +28,30 @@ namespace dsm {
   public:
     /// @brief Construct a new Itinerary object
     /// @param destination The itinerary's destination
-    Itinerary(Id id, Id destination);
+    inline Itinerary(Id id, Id destination);
     /// @brief Construct a new Itinerary object
     /// @param destination The itinerary's destination
     /// @param path An adjacency matrix made by a SparseMatrix representing the itinerary's path
-    Itinerary(Id id, Id destination, SparseMatrix<bool> path);
+    inline Itinerary(Id id, Id destination, SparseMatrix<bool> path);
 
     /// @brief Set the itinerary's destination
     /// @param destination The itinerary's destination
-    void setDestination(Id destination);
+    inline void setDestination(Id destination);
     /// @brief Set the itinerary's path
     /// @param path An adjacency matrix made by a SparseMatrix representing the itinerary's path
     /// @throw std::invalid_argument, if the itinerary's source or destination is not in the path's
-    void setPath(SparseMatrix<bool> path);
+    inline void setPath(SparseMatrix<bool> path);
 
     /// @brief Get the itinerary's id
     /// @return Id, The itinerary's id
-    Id id() const { return m_id; }
+    inline Id id() const { return m_id; }
     /// @brief Get the itinerary's destination
     /// @return Id, The itinerary's destination
-    Id destination() const { return m_destination; }
+    inline Id destination() const { return m_destination; }
     /// @brief Get the itinerary's path
     /// @return SparseMatrix<Id, bool>, An adjacency matrix made by a SparseMatrix representing the
     /// itinerary's path
-    const SparseMatrix<bool>& path() const { return m_path; }
+    inline const SparseMatrix<bool>& path() const { return m_path; }
   };
 
   Itinerary::Itinerary(Id id, Id destination)

--- a/src/dsm/headers/Itinerary.hpp
+++ b/src/dsm/headers/Itinerary.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "SparseMatrix.hpp"
+#include "../utility/Typedef.hpp"
 
 #include <concepts>
 #include <utility>
@@ -18,22 +19,20 @@
 namespace dsm {
   /// @brief The Itinerary class represents an itinerary in the network.
   /// @tparam Id The type of the itinerary's id. It must be an unsigned integral type.
-  template <typename Id>
-    requires(std::unsigned_integral<Id>)
   class Itinerary {
   private:
     Id m_id;
-    SparseMatrix<Id, bool> m_path;
+    SparseMatrix<bool> m_path;
     Id m_destination;
 
   public:
     /// @brief Construct a new Itinerary object
     /// @param destination The itinerary's destination
     Itinerary(Id id, Id destination);
-    /// @brief Construct a new Itinerary<Id>:: Itinerary object
+    /// @brief Construct a new Itinerary object
     /// @param destination The itinerary's destination
     /// @param path An adjacency matrix made by a SparseMatrix representing the itinerary's path
-    Itinerary(Id id, Id destination, SparseMatrix<Id, bool> path);
+    Itinerary(Id id, Id destination, SparseMatrix<bool> path);
 
     /// @brief Set the itinerary's destination
     /// @param destination The itinerary's destination
@@ -41,7 +40,7 @@ namespace dsm {
     /// @brief Set the itinerary's path
     /// @param path An adjacency matrix made by a SparseMatrix representing the itinerary's path
     /// @throw std::invalid_argument, if the itinerary's source or destination is not in the path's
-    void setPath(SparseMatrix<Id, bool> path);
+    void setPath(SparseMatrix<bool> path);
 
     /// @brief Get the itinerary's id
     /// @return Id, The itinerary's id
@@ -52,27 +51,21 @@ namespace dsm {
     /// @brief Get the itinerary's path
     /// @return SparseMatrix<Id, bool>, An adjacency matrix made by a SparseMatrix representing the
     /// itinerary's path
-    const SparseMatrix<Id, bool>& path() const { return m_path; }
+    const SparseMatrix<bool>& path() const { return m_path; }
   };
 
-  template <typename Id>
-    requires(std::unsigned_integral<Id>)
-  Itinerary<Id>::Itinerary(Id id, Id destination)
+  Itinerary::Itinerary(Id id, Id destination)
       : m_id{id}, m_destination{destination} {}
-  template <typename Id>
-    requires(std::unsigned_integral<Id>)
-  Itinerary<Id>::Itinerary(Id id, Id destination, SparseMatrix<Id, bool> path)
+
+  Itinerary::Itinerary(Id id, Id destination, SparseMatrix<bool> path)
       : m_id{id}, m_path{std::move(path)}, m_destination{destination} {}
 
-  template <typename Id>
-    requires(std::unsigned_integral<Id>)
-  void Itinerary<Id>::setDestination(Id destination) {
+  void Itinerary::setDestination(Id destination) {
     m_destination = destination;
     this->m_path.clear();
   }
-  template <typename Id>
-    requires(std::unsigned_integral<Id>)
-  void Itinerary<Id>::setPath(SparseMatrix<Id, bool> path) {
+
+  void Itinerary::setPath(SparseMatrix<bool> path) {
     if (path.getRowDim() != path.getColDim()) {
       throw std::invalid_argument(buildLog(
           std::format("The path's row ({}) and column ({}) dimensions must be equal.",

--- a/src/dsm/headers/Node.cpp
+++ b/src/dsm/headers/Node.cpp
@@ -1,0 +1,95 @@
+
+#include "Node.hpp"
+
+namespace dsm {
+
+  void Node::setCapacity(Size capacity) {
+    if (capacity < m_agents.size()) {
+      throw std::runtime_error(buildLog(
+          std::format("Node capacity ({}) is smaller than the current queue size ({}).",
+                      capacity,
+                      m_agents.size())));
+    }
+    NodeConcept::setCapacity(capacity);
+  }
+
+  void Node::addAgent(double angle, Id agentId) {
+    if (m_agents.size() == this->m_capacity) {
+      throw std::runtime_error(buildLog("Node is full."));
+    }
+    for (auto const [angle, id] : m_agents) {
+      if (id == agentId) {
+        throw std::runtime_error(
+            buildLog(std::format("Agent with id {} is already on the node.", agentId)));
+      }
+    }
+    auto iAngle{static_cast<int16_t>(angle * 100)};
+    m_agents.emplace(iAngle, agentId);
+    ++m_agentCounter;
+  }
+
+  void Node::addAgent(Id agentId) {
+    if (m_agents.size() == this->m_capacity) {
+      throw std::runtime_error(buildLog("Node is full."));
+    }
+    for (auto const [angle, id] : m_agents) {
+      if (id == agentId) {
+        throw std::runtime_error(
+            buildLog(std::format("Agent with id {} is already on the node.", id)));
+      }
+    }
+    int lastKey{0};
+    if (!m_agents.empty()) {
+      lastKey = m_agents.rbegin()->first + 1;
+    }
+    m_agents.emplace(lastKey, agentId);
+    ++m_agentCounter;
+  }
+
+  void Node::removeAgent(Id agentId) {
+    for (auto it{m_agents.begin()}; it != m_agents.end(); ++it) {
+      if (it->second == agentId) {
+        m_agents.erase(it);
+        return;
+      }
+    }
+    throw std::runtime_error(
+        buildLog(std::format("Agent with id {} is not on the node", agentId)));
+  }
+
+  Size Node::agentCounter() {
+    Size copy{m_agentCounter};
+    m_agentCounter = 0;
+    return copy;
+  }
+
+  Roundabout::Roundabout(const NodeConcept& node) : NodeConcept{node.id()} {
+    if (node.coords().has_value()) {
+      this->setCoords(node.coords().value());
+    }
+    this->setCapacity(node.capacity());
+  }
+
+  void Roundabout::enqueue(Id agentId) {
+    if (m_agents.size() == this->m_capacity) {
+      throw std::runtime_error(buildLog("Roundabout is full."));
+    }
+    for (const auto id : m_agents) {
+      if (id == agentId) {
+        throw std::runtime_error(buildLog(
+            std::format("Agent with id {} is already on the roundabout.", agentId)));
+      }
+    }
+    m_agents.push(agentId);
+  }
+
+  Id Roundabout::dequeue() {
+    if (m_agents.empty()) {
+      throw std::runtime_error(buildLog("Roundabout is empty."));
+    }
+    Id agentId{m_agents.front()};
+    m_agents.pop();
+    return agentId;
+  }
+
+};  // namespace dsm

--- a/src/dsm/headers/Node.cpp
+++ b/src/dsm/headers/Node.cpp
@@ -5,10 +5,10 @@ namespace dsm {
 
   void Intersection::setCapacity(Size capacity) {
     if (capacity < m_agents.size()) {
-      throw std::runtime_error(buildLog(
-          std::format("Intersection capacity ({}) is smaller than the current queue size ({}).",
-                      capacity,
-                      m_agents.size())));
+      throw std::runtime_error(buildLog(std::format(
+          "Intersection capacity ({}) is smaller than the current queue size ({}).",
+          capacity,
+          m_agents.size())));
     }
     Node::setCapacity(capacity);
   }

--- a/src/dsm/headers/Node.hpp
+++ b/src/dsm/headers/Node.hpp
@@ -50,7 +50,9 @@ namespace dsm {
     inline void setId(Id id) { m_id = id; }
     /// @brief Set the node's coordinates
     /// @param coords A std::pair containing the node's coordinates (lat, lon)
-    inline void setCoords(std::pair<double, double> coords) { m_coords = std::move(coords); }
+    inline void setCoords(std::pair<double, double> coords) {
+      m_coords = std::move(coords);
+    }
     /// @brief Set the node's capacity
     /// @param capacity The node's capacity
     inline virtual void setCapacity(Size capacity) { m_capacity = capacity; }
@@ -59,7 +61,9 @@ namespace dsm {
     inline Id id() const { return m_id; }
     /// @brief Get the node's coordinates
     /// @return std::optional<std::pair<double, double>> A std::pair containing the node's coordinates
-    inline const std::optional<std::pair<double, double>>& coords() const { return m_coords; }
+    inline const std::optional<std::pair<double, double>>& coords() const {
+      return m_coords;
+    }
     /// @brief Get the node's capacity
     /// @return Size The node's capacity
     inline Size capacity() const { return m_capacity; }
@@ -95,7 +99,7 @@ namespace dsm {
     /// @brief Set the node's capacity
     /// @param capacity The node's capacity
     /// @throws std::runtime_error if the capacity is smaller than the current queue size
-    inline void setCapacity(Size capacity) override;
+    void setCapacity(Size capacity) override;
 
     /// @brief Put an agent in the node
     /// @param agent A std::pair containing the agent's angle difference and id
@@ -103,17 +107,17 @@ namespace dsm {
     ///          The agent with the smallest angle difference is the first one to be
     ///          removed from the node.
     /// @throws std::runtime_error if the node is full
-    inline void addAgent(double angle, Id agentId);
+    void addAgent(double angle, Id agentId);
     /// @brief Put an agent in the node
     /// @param agentId The agent's id
     /// @details The agent's angle difference is used to order the agents in the node.
     ///          The agent with the smallest angle difference is the first one to be
     ///          removed from the node.
     /// @throws std::runtime_error if the node is full
-    inline void addAgent(Id agentId);
+    void addAgent(Id agentId);
     /// @brief Removes an agent from the node
     /// @param agentId The agent's id
-    inline void removeAgent(Id agentId);
+    void removeAgent(Id agentId);
     /// @brief Set the node streets with priority
     /// @param streetPriorities A std::set containing the node's street priorities
     inline void setStreetPriorities(std::set<Id> streetPriorities) {
@@ -132,7 +136,9 @@ namespace dsm {
     ///        If a street has priority, it means that the agents that are on that street
     ///        have priority over the agents that are on the other streets.
     /// @return std::set<Id> A std::set containing the node's street priorities
-    inline virtual const std::set<Id>& streetPriorities() const { return m_streetPriorities; };
+    inline virtual const std::set<Id>& streetPriorities() const {
+      return m_streetPriorities;
+    };
     /// @brief Get the node's agent ids
     /// @return std::set<Id> A std::set containing the node's agent ids
     inline std::multimap<int16_t, Id> agents() const { return m_agents; };
@@ -140,74 +146,13 @@ namespace dsm {
     /// @return Size The number of agents that have passed through the node
     /// @details This function returns the number of agents that have passed through the node
     ///          since the last time this function was called. It also resets the counter.
-    inline Size agentCounter();
+    Size agentCounter();
 
     inline virtual bool isIntersection() const noexcept override final { return true; }
   };
 
-  void Node::setCapacity(Size capacity) {
-    if (capacity < m_agents.size()) {
-      throw std::runtime_error(buildLog(
-          std::format("Node capacity ({}) is smaller than the current queue size ({}).",
-                      capacity,
-                      m_agents.size())));
-    }
-    NodeConcept::setCapacity(capacity);
-  }
-
-  void Node::addAgent(double angle, Id agentId) {
-    if (m_agents.size() == this->m_capacity) {
-      throw std::runtime_error(buildLog("Node is full."));
-    }
-    for (auto const [angle, id] : m_agents) {
-      if (id == agentId) {
-        throw std::runtime_error(
-            buildLog(std::format("Agent with id {} is already on the node.", agentId)));
-      }
-    }
-    auto iAngle{static_cast<int16_t>(angle * 100)};
-    m_agents.emplace(iAngle, agentId);
-    ++m_agentCounter;
-  }
-
-  void Node::addAgent(Id agentId) {
-    if (m_agents.size() == this->m_capacity) {
-      throw std::runtime_error(buildLog("Node is full."));
-    }
-    for (auto const [angle, id] : m_agents) {
-      if (id == agentId) {
-        throw std::runtime_error(
-            buildLog(std::format("Agent with id {} is already on the node.", id)));
-      }
-    }
-    int lastKey{0};
-    if (!m_agents.empty()) {
-      lastKey = m_agents.rbegin()->first + 1;
-    }
-    m_agents.emplace(lastKey, agentId);
-    ++m_agentCounter;
-  }
-
-  void Node::removeAgent(Id agentId) {
-    for (auto it{m_agents.begin()}; it != m_agents.end(); ++it) {
-      if (it->second == agentId) {
-        m_agents.erase(it);
-        return;
-      }
-    }
-    throw std::runtime_error(
-        buildLog(std::format("Agent with id {} is not on the node", agentId)));
-  }
-
-  Size Node::agentCounter() {
-    Size copy{m_agentCounter};
-    m_agentCounter = 0;
-    return copy;
-  }
-
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   class TrafficLight : public Node {
   private:
     std::optional<std::pair<Delay, Delay>> m_delay;
@@ -217,10 +162,10 @@ namespace dsm {
   public:
     /// @brief Construct a new TrafficLight object
     /// @param id The node's id
-    inline explicit TrafficLight(Id id) : Node{id}, m_counter{0}, m_phase{0} {};
+    explicit TrafficLight(Id id) : Node{id}, m_counter{0}, m_phase{0} {};
     /// @brief Construct a new TrafficLight object
     /// @param node A Node object
-    inline TrafficLight(const NodeConcept& node);
+    TrafficLight(const NodeConcept& node);
 
     /// @brief Set the node's delay
     /// @details This function is used to set the node's delay.
@@ -230,7 +175,7 @@ namespace dsm {
     ///          - if the counter is less than the old green delay but more than the new green delay,
     ///            it will be set to the new green delay minus the difference between the old and the new delay.
     /// @param delay The node's delay
-    inline void setDelay(Delay delay);
+    void setDelay(Delay delay);
     /// @brief Set the node's delay
     /// @details This function is used to set the node's delay.
     ///          If the delay is already set, the function will check the counter:
@@ -239,36 +184,35 @@ namespace dsm {
     ///          - if the counter is less than the old green delay but more than the new green delay,
     ///            it will be set to the new green delay minus the difference between the old and the new delay.
     /// @param delay The node's delay
-    inline void setDelay(std::pair<Delay, Delay> delay);
+    void setDelay(std::pair<Delay, Delay> delay);
     /// @brief Set the node's phase
     /// @param phase The node's phase
     /// @throw std::runtime_error if the delay is not set
-    inline void setPhase(Delay phase);
+    void setPhase(Delay phase);
     /// @brief Increase the node's counter
     /// @details This function is used to increase the node's counter
     ///          when the simulation is running. It automatically resets the counter
     ///          when it reaches the double of the delay value.
     /// @throw std::runtime_error if the delay is not set
-    inline void increaseCounter();
+    void increaseCounter();
 
     /// @brief  Set the phase of the node after the current red-green cycle has passed
     /// @param phase The new node phase
-    inline void setPhaseAfterCycle(Delay phase);
+    void setPhaseAfterCycle(Delay phase);
 
     /// @brief Get the node's delay
     /// @return std::optional<Delay> The node's delay
-    inline std::optional<std::pair<Delay, Delay>> delay() const { return m_delay; }
-    inline Delay counter() const { return m_counter; }
+    std::optional<std::pair<Delay, Delay>> delay() const { return m_delay; }
+    Delay counter() const { return m_counter; }
     /// @brief Returns true if the traffic light is green
     /// @return bool True if the traffic light is green
-    inline bool isGreen() const;
-    inline bool isGreen(Id streetId) const;
-    inline bool isTrafficLight() const noexcept override { return true; }
+    bool isGreen() const;
+    bool isGreen(Id streetId) const;
+    bool isTrafficLight() const noexcept override { return true; }
   };
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   TrafficLight<Delay>::TrafficLight(const NodeConcept& node)
       : Node{node.id()}, m_counter{0}, m_phase{0} {
     if (node.coords().has_value()) {
@@ -278,8 +222,7 @@ namespace dsm {
   }
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   void TrafficLight<Delay>::setDelay(Delay delay) {
     if (m_delay.has_value()) {
       if (m_counter >= delay + m_delay.value().second) {
@@ -294,8 +237,7 @@ namespace dsm {
   }
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   void TrafficLight<Delay>::setDelay(std::pair<Delay, Delay> delay) {
     if (m_delay.has_value()) {
       if (m_counter >= delay.first + delay.second) {
@@ -310,8 +252,7 @@ namespace dsm {
   }
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   void TrafficLight<Delay>::setPhase(Delay phase) {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
@@ -324,8 +265,7 @@ namespace dsm {
   }
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   void TrafficLight<Delay>::setPhaseAfterCycle(Delay phase) {
     if (phase > m_delay.value().first + m_delay.value().second) {
       phase -= m_delay.value().first + m_delay.value().second;
@@ -334,8 +274,7 @@ namespace dsm {
   }
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   void TrafficLight<Delay>::increaseCounter() {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
@@ -352,8 +291,7 @@ namespace dsm {
   }
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   bool TrafficLight<Delay>::isGreen() const {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
@@ -362,8 +300,7 @@ namespace dsm {
   }
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   bool TrafficLight<Delay>::isGreen(Id streetId) const {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
@@ -394,17 +331,17 @@ namespace dsm {
         : NodeConcept{id, coords} {};
     /// @brief Construct a new Roundabout object
     /// @param node A Node object
-    inline Roundabout(const NodeConcept& node);
+    Roundabout(const NodeConcept& node);
 
     virtual ~Roundabout() = default;
 
     /// @brief Put an agent in the node
     /// @param agentId The agent's id
     /// @throws std::runtime_error if the node is full
-    inline void enqueue(Id agentId);
+    void enqueue(Id agentId);
     /// @brief Removes the first agent from the node
     /// @return Id The agent's id
-    inline Id dequeue();
+    Id dequeue();
     /// @brief Get the node's queue
     /// @return dsm::queue<Id> The node's queue
     inline const dsm::queue<Id>& agents() const { return m_agents; }
@@ -417,33 +354,4 @@ namespace dsm {
     inline bool isRoundabout() const noexcept override { return true; }
   };
 
-  Roundabout::Roundabout(const NodeConcept& node)
-      : NodeConcept{node.id()} {
-    if (node.coords().has_value()) {
-      this->setCoords(node.coords().value());
-    }
-    this->setCapacity(node.capacity());
-  }
-
-  void Roundabout::enqueue(Id agentId) {
-    if (m_agents.size() == this->m_capacity) {
-      throw std::runtime_error(buildLog("Roundabout is full."));
-    }
-    for (const auto id : m_agents) {
-      if (id == agentId) {
-        throw std::runtime_error(buildLog(
-            std::format("Agent with id {} is already on the roundabout.", agentId)));
-      }
-    }
-    m_agents.push(agentId);
-  }
-
-  Id Roundabout::dequeue() {
-    if (m_agents.empty()) {
-      throw std::runtime_error(buildLog("Roundabout is empty."));
-    }
-    Id agentId{m_agents.front()};
-    m_agents.pop();
-    return agentId;
-  }
 };  // namespace dsm

--- a/src/dsm/headers/Node.hpp
+++ b/src/dsm/headers/Node.hpp
@@ -327,8 +327,7 @@ namespace dsm {
     /// @brief Construct a new Roundabout object
     /// @param id The node's id
     /// @param coords A std::pair containing the node's coordinates
-    inline Roundabout(Id id, std::pair<double, double> coords)
-        : Node{id, coords} {};
+    inline Roundabout(Id id, std::pair<double, double> coords) : Node{id, coords} {};
     /// @brief Construct a new Roundabout object
     /// @param node An Intersection object
     Roundabout(const Node& node);

--- a/src/dsm/headers/Node.hpp
+++ b/src/dsm/headers/Node.hpp
@@ -34,42 +34,43 @@ namespace dsm {
     Size m_capacity;
 
   public:
-    NodeConcept() = default;
+    inline NodeConcept() = default;
     /// @brief Construct a new Node object with capacity 1
     /// @param id The node's id
-    explicit NodeConcept(Id id) : m_id{id}, m_capacity{1} {}
+    inline explicit NodeConcept(Id id) : m_id{id}, m_capacity{1} {}
     /// @brief Construct a new Node object with capacity 1
     /// @param id The node's id
     /// @param coords A std::pair containing the node's coordinates (lat, lon)
-    NodeConcept(Id id, std::pair<double, double> coords)
+    inline NodeConcept(Id id, std::pair<double, double> coords)
         : m_id{id}, m_coords{std::move(coords)}, m_capacity{1} {}
     virtual ~NodeConcept() = default;
 
     /// @brief Set the node's id
     /// @param id The node's id
-    void setId(Id id) { m_id = id; }
+    inline void setId(Id id) { m_id = id; }
     /// @brief Set the node's coordinates
     /// @param coords A std::pair containing the node's coordinates (lat, lon)
-    void setCoords(std::pair<double, double> coords) { m_coords = std::move(coords); }
+    inline void setCoords(std::pair<double, double> coords) { m_coords = std::move(coords); }
     /// @brief Set the node's capacity
     /// @param capacity The node's capacity
-    virtual void setCapacity(Size capacity) { m_capacity = capacity; }
+    inline virtual void setCapacity(Size capacity) { m_capacity = capacity; }
     /// @brief Get the node's id
     /// @return Id The node's id
-    Id id() const { return m_id; }
+    inline Id id() const { return m_id; }
     /// @brief Get the node's coordinates
     /// @return std::optional<std::pair<double, double>> A std::pair containing the node's coordinates
-    const std::optional<std::pair<double, double>>& coords() const { return m_coords; }
+    inline const std::optional<std::pair<double, double>>& coords() const { return m_coords; }
     /// @brief Get the node's capacity
     /// @return Size The node's capacity
-    Size capacity() const { return m_capacity; }
+    inline Size capacity() const { return m_capacity; }
 
-    virtual bool isFull() const = 0;
+    inline virtual bool isFull() const = 0;
 
-    virtual bool isIntersection() const noexcept { return false; }
-    virtual bool isTrafficLight() const noexcept { return false; }
-    virtual bool isRoundabout() const noexcept { return false; }
+    inline virtual bool isIntersection() const noexcept { return false; }
+    inline virtual bool isTrafficLight() const noexcept { return false; }
+    inline virtual bool isRoundabout() const noexcept { return false; }
   };
+
   /// @brief The Node class represents a node in the network.
   /// @tparam Id The type of the node's id. It must be an unsigned integral type.
   class Node : public NodeConcept {
@@ -80,21 +81,21 @@ namespace dsm {
     Size m_agentCounter;
 
   public:
-    Node() = default;
+    inline Node() = default;
     /// @brief Construct a new Node object
     /// @param id The node's id
-    explicit Node(Id id) : NodeConcept{id} {};
+    inline explicit Node(Id id) : NodeConcept{id} {};
     /// @brief Construct a new Node object
     /// @param id The node's id
     /// @param coords A std::pair containing the node's coordinates
-    Node(Id id, std::pair<double, double> coords) : NodeConcept{id, coords} {};
+    inline Node(Id id, std::pair<double, double> coords) : NodeConcept{id, coords} {};
 
     virtual ~Node() = default;
 
     /// @brief Set the node's capacity
     /// @param capacity The node's capacity
     /// @throws std::runtime_error if the capacity is smaller than the current queue size
-    void setCapacity(Size capacity) override;
+    inline void setCapacity(Size capacity) override;
 
     /// @brief Put an agent in the node
     /// @param agent A std::pair containing the agent's angle difference and id
@@ -102,46 +103,46 @@ namespace dsm {
     ///          The agent with the smallest angle difference is the first one to be
     ///          removed from the node.
     /// @throws std::runtime_error if the node is full
-    void addAgent(double angle, Id agentId);
+    inline void addAgent(double angle, Id agentId);
     /// @brief Put an agent in the node
     /// @param agentId The agent's id
     /// @details The agent's angle difference is used to order the agents in the node.
     ///          The agent with the smallest angle difference is the first one to be
     ///          removed from the node.
     /// @throws std::runtime_error if the node is full
-    void addAgent(Id agentId);
+    inline void addAgent(Id agentId);
     /// @brief Removes an agent from the node
     /// @param agentId The agent's id
-    void removeAgent(Id agentId);
+    inline void removeAgent(Id agentId);
     /// @brief Set the node streets with priority
     /// @param streetPriorities A std::set containing the node's street priorities
-    void setStreetPriorities(std::set<Id> streetPriorities) {
+    inline void setStreetPriorities(std::set<Id> streetPriorities) {
       m_streetPriorities = std::move(streetPriorities);
     }
     /// @brief Add a street to the node street priorities
     /// @param streetId The street's id
-    void addStreetPriority(Id streetId) { m_streetPriorities.emplace(streetId); }
+    inline void addStreetPriority(Id streetId) { m_streetPriorities.emplace(streetId); }
 
     /// @brief Returns true if the node is full
     /// @return bool True if the node is full
-    bool isFull() const override { return m_agents.size() == this->m_capacity; }
+    inline bool isFull() const override { return m_agents.size() == this->m_capacity; }
 
     /// @brief Get the node's street priorities
     /// @details This function returns a std::set containing the node's street priorities.
     ///        If a street has priority, it means that the agents that are on that street
     ///        have priority over the agents that are on the other streets.
     /// @return std::set<Id> A std::set containing the node's street priorities
-    virtual const std::set<Id>& streetPriorities() const { return m_streetPriorities; };
+    inline virtual const std::set<Id>& streetPriorities() const { return m_streetPriorities; };
     /// @brief Get the node's agent ids
     /// @return std::set<Id> A std::set containing the node's agent ids
-    std::multimap<int16_t, Id> agents() const { return m_agents; };
+    inline std::multimap<int16_t, Id> agents() const { return m_agents; };
     /// @brief Returns the number of agents that have passed through the node
     /// @return Size The number of agents that have passed through the node
     /// @details This function returns the number of agents that have passed through the node
     ///          since the last time this function was called. It also resets the counter.
-    Size agentCounter();
+    inline Size agentCounter();
 
-    virtual bool isIntersection() const noexcept override final { return true; }
+    inline virtual bool isIntersection() const noexcept override final { return true; }
   };
 
   void Node::setCapacity(Size capacity) {
@@ -216,10 +217,10 @@ namespace dsm {
   public:
     /// @brief Construct a new TrafficLight object
     /// @param id The node's id
-    explicit TrafficLight(Id id) : Node{id}, m_counter{0}, m_phase{0} {};
+    inline explicit TrafficLight(Id id) : Node{id}, m_counter{0}, m_phase{0} {};
     /// @brief Construct a new TrafficLight object
     /// @param node A Node object
-    TrafficLight(const NodeConcept& node);
+    inline TrafficLight(const NodeConcept& node);
 
     /// @brief Set the node's delay
     /// @details This function is used to set the node's delay.
@@ -229,7 +230,7 @@ namespace dsm {
     ///          - if the counter is less than the old green delay but more than the new green delay,
     ///            it will be set to the new green delay minus the difference between the old and the new delay.
     /// @param delay The node's delay
-    void setDelay(Delay delay);
+    inline void setDelay(Delay delay);
     /// @brief Set the node's delay
     /// @details This function is used to set the node's delay.
     ///          If the delay is already set, the function will check the counter:
@@ -238,31 +239,31 @@ namespace dsm {
     ///          - if the counter is less than the old green delay but more than the new green delay,
     ///            it will be set to the new green delay minus the difference between the old and the new delay.
     /// @param delay The node's delay
-    void setDelay(std::pair<Delay, Delay> delay);
+    inline void setDelay(std::pair<Delay, Delay> delay);
     /// @brief Set the node's phase
     /// @param phase The node's phase
     /// @throw std::runtime_error if the delay is not set
-    void setPhase(Delay phase);
+    inline void setPhase(Delay phase);
     /// @brief Increase the node's counter
     /// @details This function is used to increase the node's counter
     ///          when the simulation is running. It automatically resets the counter
     ///          when it reaches the double of the delay value.
     /// @throw std::runtime_error if the delay is not set
-    void increaseCounter();
+    inline void increaseCounter();
 
     /// @brief  Set the phase of the node after the current red-green cycle has passed
     /// @param phase The new node phase
-    void setPhaseAfterCycle(Delay phase);
+    inline void setPhaseAfterCycle(Delay phase);
 
     /// @brief Get the node's delay
     /// @return std::optional<Delay> The node's delay
-    std::optional<std::pair<Delay, Delay>> delay() const { return m_delay; }
-    Delay counter() const { return m_counter; }
+    inline std::optional<std::pair<Delay, Delay>> delay() const { return m_delay; }
+    inline Delay counter() const { return m_counter; }
     /// @brief Returns true if the traffic light is green
     /// @return bool True if the traffic light is green
-    bool isGreen() const;
-    bool isGreen(Id streetId) const;
-    bool isTrafficLight() const noexcept override { return true; }
+    inline bool isGreen() const;
+    inline bool isGreen(Id streetId) const;
+    inline bool isTrafficLight() const noexcept override { return true; }
   };
 
   template <typename Delay>
@@ -382,38 +383,38 @@ namespace dsm {
     dsm::queue<Id> m_agents;
 
   public:
-    Roundabout() = default;
+    inline Roundabout() = default;
     /// @brief Construct a new Roundabout object
     /// @param id The node's id
-    explicit Roundabout(Id id) : NodeConcept{id} {};
+    inline explicit Roundabout(Id id) : NodeConcept{id} {};
     /// @brief Construct a new Roundabout object
     /// @param id The node's id
     /// @param coords A std::pair containing the node's coordinates
-    Roundabout(Id id, std::pair<double, double> coords)
+    inline Roundabout(Id id, std::pair<double, double> coords)
         : NodeConcept{id, coords} {};
     /// @brief Construct a new Roundabout object
     /// @param node A Node object
-    Roundabout(const NodeConcept& node);
+    inline Roundabout(const NodeConcept& node);
 
     virtual ~Roundabout() = default;
 
     /// @brief Put an agent in the node
     /// @param agentId The agent's id
     /// @throws std::runtime_error if the node is full
-    void enqueue(Id agentId);
+    inline void enqueue(Id agentId);
     /// @brief Removes the first agent from the node
     /// @return Id The agent's id
-    Id dequeue();
+    inline Id dequeue();
     /// @brief Get the node's queue
     /// @return dsm::queue<Id> The node's queue
-    const dsm::queue<Id>& agents() const { return m_agents; }
+    inline const dsm::queue<Id>& agents() const { return m_agents; }
 
     /// @brief Returns true if the node is full
     /// @return bool True if the node is full
-    bool isFull() const override { return m_agents.size() == this->m_capacity; }
+    inline bool isFull() const override { return m_agents.size() == this->m_capacity; }
     /// @brief Returns true if the node is a roundabout
     /// @return bool True if the node is a roundabout
-    bool isRoundabout() const noexcept override { return true; }
+    inline bool isRoundabout() const noexcept override { return true; }
   };
 
   Roundabout::Roundabout(const NodeConcept& node)

--- a/src/dsm/headers/Node.hpp
+++ b/src/dsm/headers/Node.hpp
@@ -21,13 +21,12 @@
 
 #include "../utility/Logger.hpp"
 #include "../utility/queue.hpp"
+#include "../utility/Typedef.hpp"
 
 namespace dsm {
   /// @brief The NodeConcept class represents the concept of a node in the network.
   /// @tparam Id The type of the node's id
   /// @tparam Size The type of the node's capacity
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class NodeConcept {
   protected:
     Id m_id;
@@ -73,9 +72,7 @@ namespace dsm {
   };
   /// @brief The Node class represents a node in the network.
   /// @tparam Id The type of the node's id. It must be an unsigned integral type.
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  class Node : public NodeConcept<Id, Size> {
+  class Node : public NodeConcept {
   protected:
     std::multimap<int16_t, Id> m_agents;
     std::set<Id>
@@ -86,11 +83,11 @@ namespace dsm {
     Node() = default;
     /// @brief Construct a new Node object
     /// @param id The node's id
-    explicit Node(Id id) : NodeConcept<Id, Size>{id} {};
+    explicit Node(Id id) : NodeConcept{id} {};
     /// @brief Construct a new Node object
     /// @param id The node's id
     /// @param coords A std::pair containing the node's coordinates
-    Node(Id id, std::pair<double, double> coords) : NodeConcept<Id, Size>{id, coords} {};
+    Node(Id id, std::pair<double, double> coords) : NodeConcept{id, coords} {};
 
     virtual ~Node() = default;
 
@@ -147,21 +144,17 @@ namespace dsm {
     virtual bool isIntersection() const noexcept override final { return true; }
   };
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Node<Id, Size>::setCapacity(Size capacity) {
+  void Node::setCapacity(Size capacity) {
     if (capacity < m_agents.size()) {
       throw std::runtime_error(buildLog(
           std::format("Node capacity ({}) is smaller than the current queue size ({}).",
                       capacity,
                       m_agents.size())));
     }
-    NodeConcept<Id, Size>::setCapacity(capacity);
+    NodeConcept::setCapacity(capacity);
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Node<Id, Size>::addAgent(double angle, Id agentId) {
+  void Node::addAgent(double angle, Id agentId) {
     if (m_agents.size() == this->m_capacity) {
       throw std::runtime_error(buildLog("Node is full."));
     }
@@ -176,9 +169,7 @@ namespace dsm {
     ++m_agentCounter;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Node<Id, Size>::addAgent(Id agentId) {
+  void Node::addAgent(Id agentId) {
     if (m_agents.size() == this->m_capacity) {
       throw std::runtime_error(buildLog("Node is full."));
     }
@@ -196,9 +187,7 @@ namespace dsm {
     ++m_agentCounter;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Node<Id, Size>::removeAgent(Id agentId) {
+  void Node::removeAgent(Id agentId) {
     for (auto it{m_agents.begin()}; it != m_agents.end(); ++it) {
       if (it->second == agentId) {
         m_agents.erase(it);
@@ -209,18 +198,16 @@ namespace dsm {
         buildLog(std::format("Agent with id {} is not on the node", agentId)));
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Size Node<Id, Size>::agentCounter() {
+  Size Node::agentCounter() {
     Size copy{m_agentCounter};
     m_agentCounter = 0;
     return copy;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  class TrafficLight : public Node<Id, Size> {
+  class TrafficLight : public Node {
   private:
     std::optional<std::pair<Delay, Delay>> m_delay;
     Delay m_counter;
@@ -229,10 +216,10 @@ namespace dsm {
   public:
     /// @brief Construct a new TrafficLight object
     /// @param id The node's id
-    explicit TrafficLight(Id id) : Node<Id, Size>{id}, m_counter{0}, m_phase{0} {};
+    explicit TrafficLight(Id id) : Node{id}, m_counter{0}, m_phase{0} {};
     /// @brief Construct a new TrafficLight object
     /// @param node A Node object
-    TrafficLight(const NodeConcept<Id, Size>& node);
+    TrafficLight(const NodeConcept& node);
 
     /// @brief Set the node's delay
     /// @details This function is used to set the node's delay.
@@ -278,21 +265,21 @@ namespace dsm {
     bool isTrafficLight() const noexcept override { return true; }
   };
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  TrafficLight<Id, Size, Delay>::TrafficLight(const NodeConcept<Id, Size>& node)
-      : Node<Id, Size>{node.id()}, m_counter{0}, m_phase{0} {
+  TrafficLight<Delay>::TrafficLight(const NodeConcept& node)
+      : Node{node.id()}, m_counter{0}, m_phase{0} {
     if (node.coords().has_value()) {
       this->setCoords(node.coords().value());
     }
     this->setCapacity(node.capacity());
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  void TrafficLight<Id, Size, Delay>::setDelay(Delay delay) {
+  void TrafficLight<Delay>::setDelay(Delay delay) {
     if (m_delay.has_value()) {
       if (m_counter >= delay + m_delay.value().second) {
         m_counter = delay + m_delay.value().second - 1;
@@ -304,10 +291,11 @@ namespace dsm {
     }
     m_delay = std::make_pair(delay, delay);
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  void TrafficLight<Id, Size, Delay>::setDelay(std::pair<Delay, Delay> delay) {
+  void TrafficLight<Delay>::setDelay(std::pair<Delay, Delay> delay) {
     if (m_delay.has_value()) {
       if (m_counter >= delay.first + delay.second) {
         m_counter = delay.first + delay.second - 1;
@@ -319,10 +307,11 @@ namespace dsm {
     }
     m_delay = std::move(delay);
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  void TrafficLight<Id, Size, Delay>::setPhase(Delay phase) {
+  void TrafficLight<Delay>::setPhase(Delay phase) {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
     }
@@ -333,20 +322,20 @@ namespace dsm {
     m_phase = 0;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  void TrafficLight<Id, Size, Delay>::setPhaseAfterCycle(Delay phase) {
+  void TrafficLight<Delay>::setPhaseAfterCycle(Delay phase) {
     if (phase > m_delay.value().first + m_delay.value().second) {
       phase -= m_delay.value().first + m_delay.value().second;
     }
     m_phase = phase;
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  void TrafficLight<Id, Size, Delay>::increaseCounter() {
+  void TrafficLight<Delay>::increaseCounter() {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
     }
@@ -361,19 +350,20 @@ namespace dsm {
     }
   }
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  bool TrafficLight<Id, Size, Delay>::isGreen() const {
+  bool TrafficLight<Delay>::isGreen() const {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
     }
     return m_counter < m_delay.value().first;
   }
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
-  bool TrafficLight<Id, Size, Delay>::isGreen(Id streetId) const {
+  bool TrafficLight<Delay>::isGreen(Id streetId) const {
     if (!m_delay.has_value()) {
       throw std::runtime_error(buildLog("TrafficLight's delay has not been set."));
     }
@@ -383,12 +373,11 @@ namespace dsm {
     }
     return !hasPriority;
   }
+
   /// @brief The Roundabout class represents a roundabout node in the network.
   /// @tparam Id The type of the node's id
   /// @tparam Size The type of the node's capacity
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  class Roundabout : public NodeConcept<Id, Size> {
+  class Roundabout : public NodeConcept {
   protected:
     dsm::queue<Id> m_agents;
 
@@ -396,15 +385,15 @@ namespace dsm {
     Roundabout() = default;
     /// @brief Construct a new Roundabout object
     /// @param id The node's id
-    explicit Roundabout(Id id) : NodeConcept<Id, Size>{id} {};
+    explicit Roundabout(Id id) : NodeConcept{id} {};
     /// @brief Construct a new Roundabout object
     /// @param id The node's id
     /// @param coords A std::pair containing the node's coordinates
     Roundabout(Id id, std::pair<double, double> coords)
-        : NodeConcept<Id, Size>{id, coords} {};
+        : NodeConcept{id, coords} {};
     /// @brief Construct a new Roundabout object
     /// @param node A Node object
-    Roundabout(const NodeConcept<Id, Size>& node);
+    Roundabout(const NodeConcept& node);
 
     virtual ~Roundabout() = default;
 
@@ -426,18 +415,16 @@ namespace dsm {
     /// @return bool True if the node is a roundabout
     bool isRoundabout() const noexcept override { return true; }
   };
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Roundabout<Id, Size>::Roundabout(const NodeConcept<Id, Size>& node)
-      : NodeConcept<Id, Size>{node.id()} {
+
+  Roundabout::Roundabout(const NodeConcept& node)
+      : NodeConcept{node.id()} {
     if (node.coords().has_value()) {
       this->setCoords(node.coords().value());
     }
     this->setCapacity(node.capacity());
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Roundabout<Id, Size>::enqueue(Id agentId) {
+
+  void Roundabout::enqueue(Id agentId) {
     if (m_agents.size() == this->m_capacity) {
       throw std::runtime_error(buildLog("Roundabout is full."));
     }
@@ -449,9 +436,8 @@ namespace dsm {
     }
     m_agents.push(agentId);
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Id Roundabout<Id, Size>::dequeue() {
+
+  Id Roundabout::dequeue() {
     if (m_agents.empty()) {
       throw std::runtime_error(buildLog("Roundabout is empty."));
     }

--- a/src/dsm/headers/SparseMatrix.hpp
+++ b/src/dsm/headers/SparseMatrix.hpp
@@ -310,10 +310,7 @@ namespace dsm {
 
   template <typename T>
   SparseMatrix<T>::SparseMatrix(Id index)
-      : _matrix{std::unordered_map<Id, T>()},
-        _rows{index},
-        _cols{1},
-        _defaultReturn{0} {}
+      : _matrix{std::unordered_map<Id, T>()}, _rows{index}, _cols{1}, _defaultReturn{0} {}
 
   template <typename T>
   void SparseMatrix<T>::insert(Id i, Id j, T value) {
@@ -367,8 +364,8 @@ namespace dsm {
   template <typename T>
   void SparseMatrix<T>::erase(Id i, Id j) {
     if (i >= _rows || j >= _cols) {
-      throw std::out_of_range(buildLog(
-          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+      throw std::out_of_range(
+          buildLog(std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     if (_matrix.find(i * _cols + j) == _matrix.end()) {
       throw std::runtime_error(
@@ -457,8 +454,8 @@ namespace dsm {
   template <typename T>
   bool SparseMatrix<T>::contains(Id i, Id j) const {
     if (i >= _rows || j >= _cols) {
-      throw std::out_of_range(buildLog(
-          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+      throw std::out_of_range(
+          buildLog(std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     return _matrix.contains(i * _cols + j);
   }
@@ -516,8 +513,7 @@ namespace dsm {
   }
 
   template <typename T>
-  SparseMatrix<T> SparseMatrix<T>::getRow(Id index,
-                                                        bool keepId) const {
+  SparseMatrix<T> SparseMatrix<T>::getRow(Id index, bool keepId) const {
     if (index >= _rows) {
       throw std::out_of_range(
           buildLog(std::format("Id {} out of range 0-{}", index, _rows - 1)));
@@ -529,15 +525,14 @@ namespace dsm {
     for (auto& it : _matrix) {
       if (it.first / _cols == index) {
         keepId ? row.insert(it.first, it.second)
-                  : row.insert(it.first % _cols, it.second);
+               : row.insert(it.first % _cols, it.second);
       }
     }
     return row;
   }
 
   template <typename T>
-  SparseMatrix<T> SparseMatrix<T>::getCol(Id index,
-                                                        bool keepId) const {
+  SparseMatrix<T> SparseMatrix<T>::getCol(Id index, bool keepId) const {
     if (index >= _cols) {
       throw std::out_of_range(
           buildLog(std::format("Id {} out of range 0-{}", index, _cols - 1)));
@@ -549,7 +544,7 @@ namespace dsm {
     for (auto& it : _matrix) {
       if (it.first % _cols == index) {
         keepId ? col.insert(it.first, it.second)
-                  : col.insert(it.first / _cols, it.second);
+               : col.insert(it.first / _cols, it.second);
       }
     }
     return col;
@@ -624,8 +619,8 @@ namespace dsm {
   template <typename T>
   const T& SparseMatrix<T>::operator()(Id i, Id j) const {
     if (i >= _rows || j >= _cols) {
-      throw std::out_of_range(buildLog(
-          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+      throw std::out_of_range(
+          buildLog(std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     auto const& it = _matrix.find(i * _cols + j);
     return it != _matrix.end() ? it->second : _defaultReturn;
@@ -634,8 +629,8 @@ namespace dsm {
   template <typename T>
   T& SparseMatrix<T>::operator()(Id i, Id j) {
     if (i >= _rows || j >= _cols) {
-      throw std::out_of_range(buildLog(
-          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+      throw std::out_of_range(
+          buildLog(std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     auto const& it = _matrix.find(i * _cols + j);
     return it != _matrix.end() ? it->second : _defaultReturn;
@@ -672,8 +667,7 @@ namespace dsm {
 
   template <typename T>
   template <typename U>
-  SparseMatrix<T>& SparseMatrix<T>::operator+=(
-      const SparseMatrix<U>& other) {
+  SparseMatrix<T>& SparseMatrix<T>::operator+=(const SparseMatrix<U>& other) {
     if (this->_rows != other._rows || this->_cols != other._cols) {
       throw std::runtime_error(
           buildLog(std::format("Dimensions ({}, {}) and ({}, {}) do not match",
@@ -692,8 +686,7 @@ namespace dsm {
 
   template <typename T>
   template <typename U>
-  SparseMatrix<T>& SparseMatrix<T>::operator-=(
-      const SparseMatrix<U>& other) {
+  SparseMatrix<T>& SparseMatrix<T>::operator-=(const SparseMatrix<U>& other) {
     if (this->_rows != other._rows || this->_cols != other._cols) {
       throw std::runtime_error(
           buildLog(std::format("Dimensions ({}, {}) and ({}, {}) do not match",

--- a/src/dsm/headers/SparseMatrix.hpp
+++ b/src/dsm/headers/SparseMatrix.hpp
@@ -19,16 +19,16 @@
 #include <format>
 
 #include "../utility/Logger.hpp"
+#include "../utility/Typedef.hpp"
 
 namespace dsm {
   /// @brief The SparseMatrix class represents a sparse matrix.
-  /// @tparam Index The type of the matrix's index. It must be an unsigned integral type.
+  /// @tparam Id The type of the matrix's index. It must be an unsigned integral type.
   /// @tparam T The type of the matrix's value.
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
+  template <typename T>
   class SparseMatrix {
-    std::unordered_map<Index, T> _matrix;
-    Index _rows, _cols;
+    std::unordered_map<Id, T> _matrix;
+    Id _rows, _cols;
     T _defaultReturn;
 
   public:
@@ -38,25 +38,25 @@ namespace dsm {
     /// @param rows number of rows
     /// @param cols number of columns
     /// @throw std::invalid_argument if rows or cols are < 0
-    SparseMatrix(Index rows, Index cols);
+    SparseMatrix(Id rows, Id cols);
 
     /// @brief SparseMatrix constructor - colum
     /// @param index number of rows
     /// @throw std::invalid_argument if index is < 0
-    explicit SparseMatrix(Index index);
+    explicit SparseMatrix(Id index);
 
     /// @brief insert a value in the matrix
     /// @param i row index
     /// @param j column index
     /// @param value value to insert
     /// @throw std::out_of_range if the index is out of range
-    void insert(Index i, Index j, T value);
+    void insert(Id i, Id j, T value);
 
     /// @brief insert a value in the matrix
     /// @param i index
     /// @param value value to insert
     /// @throw std::out_of_range if the index is out of range
-    void insert(Index i, T value);
+    void insert(Id i, T value);
 
     /// @brief insert a value in the matrix. If the element already exist, it
     /// overwrites it
@@ -64,49 +64,49 @@ namespace dsm {
     /// @param j column index
     /// @param value value to insert
     /// @throw std::out_of_range if the index is out of range
-    void insert_or_assign(Index i, Index j, T value);
+    void insert_or_assign(Id i, Id j, T value);
 
     /// @brief insert a value in the matrix. If the element already exist, it
     /// overwrites it
     /// @param index index in vectorial form
     /// @param value value to insert
     /// @throw std::out_of_range if the index is out of range
-    void insert_or_assign(Index index, T value);
+    void insert_or_assign(Id index, T value);
 
     /// @brief insert a value in the matrix and expand the matrix if necessary.
     /// @param i row index
     /// @param j column index
     /// @param value value to insert
-    void insert_and_expand(Index i, Index j, T value);
+    void insert_and_expand(Id i, Id j, T value);
 
     /// @brief remove a value from the matrix
     /// @param i row index
     /// @param j column index
     /// @throw std::out_of_range if the index is out of range
     /// @throw std::runtime_error if the element is not found
-    void erase(Index i, Index j);
+    void erase(Id i, Id j);
 
     /// @brief remove a value from the matrix
     /// @param index index in vectorial form
     /// @throw std::out_of_range if the index is out of range
     /// @throw std::runtime_error if the element is not found
-    void erase(Index index);
+    void erase(Id index);
 
     /// @brief remove a row from the matrix
     /// @param index row index
     /// @throw std::out_of_range if the index is out of range
-    void eraseRow(Index index);
+    void eraseRow(Id index);
 
     /// @brief remove a column from the matrix
     /// @param index column index
     /// @throw std::out_of_range if the index is out of range
-    void eraseColumn(Index index);
+    void eraseColumn(Id index);
 
     /// @brief set to 0 all the elements in a row
-    void emptyRow(Index index);
+    void emptyRow(Id index);
 
     /// @brief set to 0 all the elements in a column
-    void emptyColumn(Index index);
+    void emptyColumn(Id index);
 
     /// @brief empty the matrix and set the dimensions to zero
     void clear();
@@ -116,89 +116,89 @@ namespace dsm {
     /// @param j column index
     /// @return true if the element is non zero
     /// @throw std::out_of_range if the index is out of range
-    bool contains(Index i, Index j) const;
+    bool contains(Id i, Id j) const;
 
     /// @brief check if the element is non zero
     /// @param index index in vectorial form
     /// @return true if the element is non zero
     /// @throw std::out_of_range if the index is out of range
-    bool contains(Index const index) const;
+    bool contains(Id const index) const;
 
     /// @brief get the input degree of all nodes
     /// @return a SparseMatrix vector with the input degree of all nodes
     /// @throw std::runtime_error if the matrix is not square
-    SparseMatrix<Index, int> getDegreeVector() const;
+    SparseMatrix<int> getDegreeVector() const;
 
     /// @brief get the strength of all nodes
     /// @return a SparseMatrix vector with the strength of all nodes
     /// @throw std::runtime_error if the matrix is not square
-    SparseMatrix<Index, double> getStrengthVector() const;
+    SparseMatrix<double> getStrengthVector() const;
 
     /// @brief get the laplacian matrix
     /// @return the laplacian matrix
     /// @throw std::runtime_error if the matrix is not square
-    SparseMatrix<Index, int> getLaplacian() const;
+    SparseMatrix<int> getLaplacian() const;
 
     /// @brief get a row as a row vector
     /// @param index row index
-    /// @param keepIndex if true, the index of the elements in the row will be
+    /// @param keepId if true, the index of the elements in the row will be
     /// the same as the index of the elements in the matrix
-    /// @return a row vector if keepIndex is false, otherwise a matrix with the
+    /// @return a row vector if keepId is false, otherwise a matrix with the
     /// same dimensions as the original matrix
     /// @throw std::out_of_range if the index is out of range
-    SparseMatrix getRow(Index index, bool keepIndex = false) const;
+    SparseMatrix getRow(Id index, bool keepId = false) const;
 
     /// @brief get a column as a column vector
     /// @param index column index
-    /// @param keepIndex if true, the index of the elements in the column will
+    /// @param keepId if true, the index of the elements in the column will
     /// be the same as the index of the elements in the matrix
-    /// @return a column vector if keepIndex is false, otherwise a matrix with
+    /// @return a column vector if keepId is false, otherwise a matrix with
     /// the same dimensions as the original matrix
     /// @throw std::out_of_range if the index is out of range
-    SparseMatrix getCol(Index index, bool keepIndex = false) const;
+    SparseMatrix getCol(Id index, bool keepId = false) const;
 
     /// @brief get a matrix of double with every row normalized to 1
     /// @return a matrix of double
-    SparseMatrix<Index, double> getNormRows() const;
+    SparseMatrix<double> getNormRows() const;
 
     /// @brief get a matrix of double with every column normalized to 1
     /// @return a matrix of double
-    SparseMatrix<Index, double> getNormCols() const;
+    SparseMatrix<double> getNormCols() const;
 
     /// @brief get the number of rows
     /// @return number of rows
-    Index getRowDim() const { return _rows; }
+    Id getRowDim() const { return _rows; }
 
     /// @brief get the number of columns
     /// @return number of columns
-    Index getColDim() const { return _cols; }
+    Id getColDim() const { return _cols; }
 
     /// @brief get the number of non zero elements in the matrix
     /// @return number of non zero elements
-    Index size() const { return _matrix.size(); };
+    Id size() const { return _matrix.size(); };
 
     /// @brief get the maximum number of elements in the matrix
     /// @return maximum number of elements
-    Index max_size() const { return _rows * _cols; }
+    Id max_size() const { return _rows * _cols; }
 
     /// @brief symmetrize the matrix
     void symmetrize();
 
     /// @brief reshape the matrix
-    void reshape(Index rows, Index cols);
+    void reshape(Id rows, Id cols);
 
     /// @brief reshape the matrix
-    void reshape(Index dim);
+    void reshape(Id dim);
 
     /// @brief return the begin iterator of the matrix
     /// @return the begin iterator
-    typename std::unordered_map<Index, T>::const_iterator begin() const {
+    typename std::unordered_map<Id, T>::const_iterator begin() const {
       return _matrix.begin();
     }
 
     /// @brief return the end iterator of the matrix
     /// @return the end iterator
-    typename std::unordered_map<Index, T>::const_iterator end() const {
+    typename std::unordered_map<Id, T>::const_iterator end() const {
       return _matrix.end();
     }
 
@@ -207,39 +207,38 @@ namespace dsm {
     /// @param j column index
     /// @return the element
     /// @throw std::out_of_range if the index is out of range
-    const T& operator()(Index i, Index j) const;
+    const T& operator()(Id i, Id j) const;
 
     /// @brief access an element of the matrix
     /// @param i row index
     /// @param j column index
     /// @return the element
     /// @throw std::out_of_range if the index is out of range
-    T& operator()(Index i, Index j);
+    T& operator()(Id i, Id j);
 
     /// @brief access an element of the matrix
     /// @param index index in vectorial form
     /// @return the element
     /// @throw std::out_of_range if the index is out of range
-    const T& operator()(Index index) const;
+    const T& operator()(Id index) const;
 
     /// @brief access an element of the matrix
     /// @param index index in vectorial form
     /// @return the element
     /// @throw std::out_of_range if the index is out of range
-    T& operator()(Index index);
+    T& operator()(Id index);
 
     /// @brief sum of two matrices
     /// @param other the other matrix
     /// @return the sum of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
-    template <typename I, typename U>
-      requires std::unsigned_integral<I>
-    SparseMatrix<Index, T> operator+(const SparseMatrix<I, U>& other) {
+    template <typename U>
+    SparseMatrix<T> operator+(const SparseMatrix<U>& other) {
       if (this->_rows != other._rows || this->_cols != other._cols) {
         throw std::runtime_error(buildLog("Dimensions do not match"));
       }
-      auto result = SparseMatrix<Index, T>(this->_rows, this->_cols);
-      std::unordered_map<Index, bool> unique;
+      auto result = SparseMatrix<T>(this->_rows, this->_cols);
+      std::unordered_map<Id, bool> unique;
       for (auto& it : this->_matrix) {
         unique.insert_or_assign(it.first, true);
       }
@@ -258,14 +257,13 @@ namespace dsm {
     /// @param other the other matrix
     /// @return the difference of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
-    template <typename I, typename U>
-      requires std::unsigned_integral<I>
-    SparseMatrix<Index, T> operator-(const SparseMatrix<I, U>& other) {
+    template <typename U>
+    SparseMatrix<T> operator-(const SparseMatrix<U>& other) {
       if (this->_rows != other._rows || this->_cols != other._cols) {
         throw std::runtime_error(buildLog("Dimensions do not match"));
       }
       auto result = SparseMatrix(this->_rows, this->_cols);
-      std::unordered_map<Index, bool> unique;
+      std::unordered_map<Id, bool> unique;
       for (auto& it : this->_matrix) {
         unique.insert_or_assign(it.first, true);
       }
@@ -288,79 +286,69 @@ namespace dsm {
     /// @param other the other matrix
     /// @return the sum of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
-    template <typename I, typename U>
-      requires std::unsigned_integral<I>
-    SparseMatrix& operator+=(const SparseMatrix<I, U>& other);
+    template <typename U>
+    SparseMatrix& operator+=(const SparseMatrix<U>& other);
 
     /// @brief difference of two matrices
     /// @param other the other matrix
     /// @return the difference of the two matrices
     /// @throw std::runtime_error if the dimensions do not match
-    template <typename I, typename U>
-      requires std::unsigned_integral<I>
-    SparseMatrix& operator-=(const SparseMatrix<I, U>& other);
+    template <typename U>
+    SparseMatrix& operator-=(const SparseMatrix<U>& other);
   };
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, T>::SparseMatrix()
-      : _matrix{std::unordered_map<Index, T>()}, _rows{}, _cols{}, _defaultReturn{0} {}
+  template <typename T>
+  SparseMatrix<T>::SparseMatrix()
+      : _matrix{std::unordered_map<Id, T>()}, _rows{}, _cols{}, _defaultReturn{0} {}
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, T>::SparseMatrix(Index rows, Index cols)
-      : _matrix{std::unordered_map<Index, T>()},
+  template <typename T>
+  SparseMatrix<T>::SparseMatrix(Id rows, Id cols)
+      : _matrix{std::unordered_map<Id, T>()},
         _rows{rows},
         _cols{cols},
         _defaultReturn{0} {}
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, T>::SparseMatrix(Index index)
-      : _matrix{std::unordered_map<Index, T>()},
+  template <typename T>
+  SparseMatrix<T>::SparseMatrix(Id index)
+      : _matrix{std::unordered_map<Id, T>()},
         _rows{index},
         _cols{1},
         _defaultReturn{0} {}
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::insert(Index i, Index j, T value) {
+  template <typename T>
+  void SparseMatrix<T>::insert(Id i, Id j, T value) {
     const auto index = i * _cols + j;
     this->insert(index, value);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::insert(Index i, T value) {
+  template <typename T>
+  void SparseMatrix<T>::insert(Id i, T value) {
     if (i > _rows * _cols - 1) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", i, _rows * _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", i, _rows * _cols - 1)));
     }
     _matrix.emplace(std::make_pair(i, value));
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::insert_or_assign(Index i, Index j, T value) {
+  template <typename T>
+  void SparseMatrix<T>::insert_or_assign(Id i, Id j, T value) {
     const auto index = i * _cols + j;
     this->insert_or_assign(index, value);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::insert_or_assign(Index index, T value) {
+  template <typename T>
+  void SparseMatrix<T>::insert_or_assign(Id index, T value) {
     if (index > _rows * _cols - 1) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _rows * _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _rows * _cols - 1)));
     }
     _matrix.insert_or_assign(index, value);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::insert_and_expand(Index i, Index j, T value) {
+  template <typename T>
+  void SparseMatrix<T>::insert_and_expand(Id i, Id j, T value) {
     if (!(i < _rows) || !(j < _cols)) {
-      Index delta = std::max(i - _rows, j - _cols);
+      Id delta = std::max(i - _rows, j - _cols);
       if (_cols == 1) {
         if (!((i + delta) < (_rows + delta))) {
           ++delta;
@@ -376,12 +364,11 @@ namespace dsm {
     _matrix.insert_or_assign(i * _cols + j, value);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::erase(Index i, Index j) {
+  template <typename T>
+  void SparseMatrix<T>::erase(Id i, Id j) {
     if (i >= _rows || j >= _cols) {
       throw std::out_of_range(buildLog(
-          std::format("Index ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     if (_matrix.find(i * _cols + j) == _matrix.end()) {
       throw std::runtime_error(
@@ -390,12 +377,11 @@ namespace dsm {
     _matrix.erase(i * _cols + j);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::erase(Index index) {
+  template <typename T>
+  void SparseMatrix<T>::erase(Id index) {
     if (index > _rows * _cols - 1) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _rows * _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _rows * _cols - 1)));
     }
     if (_matrix.find(index) == _matrix.end()) {
       throw std::runtime_error(
@@ -404,17 +390,16 @@ namespace dsm {
     _matrix.erase(index);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::eraseRow(Index index) {
+  template <typename T>
+  void SparseMatrix<T>::eraseRow(Id index) {
     if (index > _rows - 1) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _rows - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _rows - 1)));
     }
-    for (Index i = 0; i < _cols; ++i) {
+    for (Id i = 0; i < _cols; ++i) {
       _matrix.erase(index * _cols + i);
     }
-    std::unordered_map<Index, T> new_matrix = {};
+    std::unordered_map<Id, T> new_matrix = {};
     for (auto const& [key, value] : _matrix) {
       if (key / _cols < index) {
         new_matrix.emplace(std::make_pair(key, value));
@@ -426,17 +411,16 @@ namespace dsm {
     _matrix = new_matrix;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::eraseColumn(Index index) {
+  template <typename T>
+  void SparseMatrix<T>::eraseColumn(Id index) {
     if (index > _cols - 1) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _cols - 1)));
     }
-    for (Index i = 0; i < _rows; ++i) {
+    for (Id i = 0; i < _rows; ++i) {
       _matrix.erase(i * _cols + index);
     }
-    std::unordered_map<Index, T> new_matrix = {};
+    std::unordered_map<Id, T> new_matrix = {};
     for (auto const& [key, value] : _matrix) {
       if (key % _cols < index) {
         new_matrix.emplace(std::make_pair(key - key / _cols, value));
@@ -449,57 +433,51 @@ namespace dsm {
     _matrix = new_matrix;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::emptyRow(Index index) {
+  template <typename T>
+  void SparseMatrix<T>::emptyRow(Id index) {
     for (const auto& x : this->getRow(index)) {
       _matrix.erase(index * _cols + x.first);
     }
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::emptyColumn(Index index) {
+  template <typename T>
+  void SparseMatrix<T>::emptyColumn(Id index) {
     for (const auto& x : this->getCol(index)) {
       _matrix.erase(x.first * _cols + index);
     }
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::clear() {
+  template <typename T>
+  void SparseMatrix<T>::clear() {
     _matrix.clear();
     _rows = 0;
     _cols = 0;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  bool SparseMatrix<Index, T>::contains(Index i, Index j) const {
+  template <typename T>
+  bool SparseMatrix<T>::contains(Id i, Id j) const {
     if (i >= _rows || j >= _cols) {
       throw std::out_of_range(buildLog(
-          std::format("Index ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     return _matrix.contains(i * _cols + j);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  bool SparseMatrix<Index, T>::contains(Index const index) const {
+  template <typename T>
+  bool SparseMatrix<T>::contains(Id const index) const {
     if (index > _rows * _cols - 1) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _rows * _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _rows * _cols - 1)));
     }
     return _matrix.contains(index);
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, int> SparseMatrix<Index, T>::getDegreeVector() const {
+  template <typename T>
+  SparseMatrix<int> SparseMatrix<T>::getDegreeVector() const {
     if (_rows != _cols) {
       throw std::runtime_error(buildLog("getDegreeVector only works on square matrices"));
     }
-    auto degreeVector = SparseMatrix<Index, int>(_rows, 1);
+    auto degreeVector = SparseMatrix<int>(_rows, 1);
     for (auto& i : _matrix) {
       degreeVector.insert_or_assign(
           i.first / _cols, 0, degreeVector(i.first / _cols, 0) + 1);
@@ -507,14 +485,13 @@ namespace dsm {
     return degreeVector;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, double> SparseMatrix<Index, T>::getStrengthVector() const {
+  template <typename T>
+  SparseMatrix<double> SparseMatrix<T>::getStrengthVector() const {
     if (_rows != _cols) {
       throw std::runtime_error(
           buildLog("getStrengthVector only works on square matrices"));
     }
-    auto strengthVector = SparseMatrix<Index, double>(_rows, 1);
+    auto strengthVector = SparseMatrix<double>(_rows, 1);
     for (auto& i : _matrix) {
       strengthVector.insert_or_assign(
           i.first / _cols, 0, strengthVector(i.first / _cols, 0) + i.second);
@@ -522,70 +499,66 @@ namespace dsm {
     return strengthVector;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, int> SparseMatrix<Index, T>::getLaplacian() const {
+  template <typename T>
+  SparseMatrix<int> SparseMatrix<T>::getLaplacian() const {
     if (_rows != _cols) {
       throw std::runtime_error(buildLog("getLaplacian only works on square matrices"));
     }
-    auto laplacian = SparseMatrix<Index, int>(_rows, _cols);
+    auto laplacian = SparseMatrix<int>(_rows, _cols);
     for (auto& i : _matrix) {
       laplacian.insert_or_assign(i.first / _cols, i.first % _cols, -1);
     }
     auto degreeVector = this->getDegreeVector();
-    for (Index i = 0; i < _rows; ++i) {
+    for (Id i = 0; i < _rows; ++i) {
       laplacian.insert_or_assign(i, i, degreeVector(i, 0));
     }
     return laplacian;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, T> SparseMatrix<Index, T>::getRow(Index index,
-                                                        bool keepIndex) const {
+  template <typename T>
+  SparseMatrix<T> SparseMatrix<T>::getRow(Id index,
+                                                        bool keepId) const {
     if (index >= _rows) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _rows - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _rows - 1)));
     }
     SparseMatrix row(1, _cols);
-    if (keepIndex) {
+    if (keepId) {
       row.reshape(_rows, _cols);
     }
     for (auto& it : _matrix) {
       if (it.first / _cols == index) {
-        keepIndex ? row.insert(it.first, it.second)
+        keepId ? row.insert(it.first, it.second)
                   : row.insert(it.first % _cols, it.second);
       }
     }
     return row;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, T> SparseMatrix<Index, T>::getCol(Index index,
-                                                        bool keepIndex) const {
+  template <typename T>
+  SparseMatrix<T> SparseMatrix<T>::getCol(Id index,
+                                                        bool keepId) const {
     if (index >= _cols) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _cols - 1)));
     }
     SparseMatrix col(_rows, 1);
-    if (keepIndex) {
+    if (keepId) {
       col.reshape(_rows, _cols);
     }
     for (auto& it : _matrix) {
       if (it.first % _cols == index) {
-        keepIndex ? col.insert(it.first, it.second)
+        keepId ? col.insert(it.first, it.second)
                   : col.insert(it.first / _cols, it.second);
       }
     }
     return col;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, double> SparseMatrix<Index, T>::getNormRows() const {
-    SparseMatrix<Index, double> normRows(_rows, _cols);
-    for (Index index = 0; index < _rows; ++index) {
+  template <typename T>
+  SparseMatrix<double> SparseMatrix<T>::getNormRows() const {
+    SparseMatrix<double> normRows(_rows, _cols);
+    for (Id index = 0; index < _rows; ++index) {
       auto row = this->getRow(index, true);
       double sum = 0.;
       for (auto& it : row) {
@@ -599,11 +572,10 @@ namespace dsm {
     return normRows;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, double> SparseMatrix<Index, T>::getNormCols() const {
-    SparseMatrix<Index, double> normCols(_rows, _cols);
-    for (Index index = 0; index < _cols; ++index) {
+  template <typename T>
+  SparseMatrix<double> SparseMatrix<T>::getNormCols() const {
+    SparseMatrix<double> normCols(_rows, _cols);
+    for (Id index = 0; index < _cols; ++index) {
       auto col = this->getCol(index, true);
       double sum = 0.;
       for (auto& it : col) {
@@ -617,16 +589,14 @@ namespace dsm {
     return normCols;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::symmetrize() {
+  template <typename T>
+  void SparseMatrix<T>::symmetrize() {
     *this += this->operator++();
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::reshape(Index rows, Index cols) {
-    Index oldCols = this->_cols;
+  template <typename T>
+  void SparseMatrix<T>::reshape(Id rows, Id cols) {
+    Id oldCols = this->_cols;
     this->_rows = rows;
     this->_cols = cols;
     auto copy = _matrix;
@@ -638,9 +608,8 @@ namespace dsm {
     }
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  void SparseMatrix<Index, T>::reshape(Index index) {
+  template <typename T>
+  void SparseMatrix<T>::reshape(Id index) {
     this->_rows = index;
     this->_cols = 1;
     auto copy = _matrix;
@@ -652,53 +621,48 @@ namespace dsm {
     }
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  const T& SparseMatrix<Index, T>::operator()(Index i, Index j) const {
+  template <typename T>
+  const T& SparseMatrix<T>::operator()(Id i, Id j) const {
     if (i >= _rows || j >= _cols) {
       throw std::out_of_range(buildLog(
-          std::format("Index ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     auto const& it = _matrix.find(i * _cols + j);
     return it != _matrix.end() ? it->second : _defaultReturn;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  T& SparseMatrix<Index, T>::operator()(Index i, Index j) {
+  template <typename T>
+  T& SparseMatrix<T>::operator()(Id i, Id j) {
     if (i >= _rows || j >= _cols) {
       throw std::out_of_range(buildLog(
-          std::format("Index ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
+          std::format("Id ({}, {}) out of range ({}, {})", i, j, _rows, _cols)));
     }
     auto const& it = _matrix.find(i * _cols + j);
     return it != _matrix.end() ? it->second : _defaultReturn;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  const T& SparseMatrix<Index, T>::operator()(Index index) const {
+  template <typename T>
+  const T& SparseMatrix<T>::operator()(Id index) const {
     if (index >= _rows * _cols) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _rows * _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _rows * _cols - 1)));
     }
     auto const& it = _matrix.find(index);
     return it != _matrix.end() ? it->second : _defaultReturn;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  T& SparseMatrix<Index, T>::operator()(Index index) {
+  template <typename T>
+  T& SparseMatrix<T>::operator()(Id index) {
     if (index >= _rows * _cols) {
       throw std::out_of_range(
-          buildLog(std::format("Index {} out of range 0-{}", index, _rows * _cols - 1)));
+          buildLog(std::format("Id {} out of range 0-{}", index, _rows * _cols - 1)));
     }
     auto const& it = _matrix.find(index);
     return it != _matrix.end() ? it->second : _defaultReturn;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  SparseMatrix<Index, T> SparseMatrix<Index, T>::operator++() {
+  template <typename T>
+  SparseMatrix<T> SparseMatrix<T>::operator++() {
     auto transpost = SparseMatrix(this->_cols, this->_rows);
     for (auto& it : _matrix) {
       transpost.insert(it.first % _cols, it.first / _cols, it.second);
@@ -706,12 +670,10 @@ namespace dsm {
     return transpost;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  template <typename I, typename U>
-    requires std::unsigned_integral<I>
-  SparseMatrix<Index, T>& SparseMatrix<Index, T>::operator+=(
-      const SparseMatrix<I, U>& other) {
+  template <typename T>
+  template <typename U>
+  SparseMatrix<T>& SparseMatrix<T>::operator+=(
+      const SparseMatrix<U>& other) {
     if (this->_rows != other._rows || this->_cols != other._cols) {
       throw std::runtime_error(
           buildLog(std::format("Dimensions ({}, {}) and ({}, {}) do not match",
@@ -728,12 +690,10 @@ namespace dsm {
     return *this;
   }
 
-  template <typename Index, typename T>
-    requires(std::unsigned_integral<Index>)
-  template <typename I, typename U>
-    requires std::unsigned_integral<I>
-  SparseMatrix<Index, T>& SparseMatrix<Index, T>::operator-=(
-      const SparseMatrix<I, U>& other) {
+  template <typename T>
+  template <typename U>
+  SparseMatrix<T>& SparseMatrix<T>::operator-=(
+      const SparseMatrix<U>& other) {
     if (this->_rows != other._rows || this->_cols != other._cols) {
       throw std::runtime_error(
           buildLog(std::format("Dimensions ({}, {}) and ({}, {}) do not match",

--- a/src/dsm/headers/Street.cpp
+++ b/src/dsm/headers/Street.cpp
@@ -1,0 +1,160 @@
+
+#include "Street.hpp"
+
+namespace dsm {
+  Street::Street(Id id, const Street& street)
+      : m_nodePair{street.nodePair()},
+        m_len{street.length()},
+        m_maxSpeed{street.maxSpeed()},
+        m_angle{street.angle()},
+        m_id{id},
+        m_capacity{street.capacity()},
+        m_transportCapacity{street.transportCapacity()} {}
+
+  Street::Street(Id index, std::pair<Id, Id> pair)
+      : m_nodePair{std::move(pair)},
+        m_len{1.},
+        m_maxSpeed{13.8888888889},
+        m_angle{0.},
+        m_id{index},
+        m_capacity{1},
+        m_transportCapacity{std::numeric_limits<Size>::max()} {}
+
+  Street::Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair)
+      : m_nodePair{std::move(nodePair)},
+        m_len{len},
+        m_maxSpeed{13.8888888889},
+        m_angle{0.},
+        m_id{id},
+        m_capacity{capacity},
+        m_transportCapacity{std::numeric_limits<Size>::max()} {}
+
+  Street::Street(
+      Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
+      : m_nodePair{std::move(nodePair)},
+        m_len{len},
+        m_angle{0.},
+        m_id{id},
+        m_capacity{capacity},
+        m_transportCapacity{std::numeric_limits<Size>::max()} {
+    this->setMaxSpeed(maxSpeed);
+  }
+
+  void Street::setLength(double len) {
+    if (len < 0.) {
+      throw std::invalid_argument(
+          buildLog(std::format("The length of a street ({}) cannot be negative.", len)));
+    }
+    m_len = len;
+  }
+  void Street::setMaxSpeed(double speed) {
+    if (speed < 0.) {
+      throw std::invalid_argument(buildLog(
+          std::format("The maximum speed of a street ({}) cannot be negative.", speed)));
+    }
+    m_maxSpeed = speed;
+  }
+  void Street::setAngle(std::pair<double, double> srcNode,
+                        std::pair<double, double> dstNode) {
+    // N.B.: lat, lon <==> y, x
+    double delta_y{dstNode.first - srcNode.first};
+    double delta_x{dstNode.second - srcNode.second};
+    double angle{std::atan2(delta_y, delta_x)};
+    if (angle < 0.) {
+      angle += 2 * std::numbers::pi;
+    }
+    this->setAngle(angle);
+  }
+  void Street::setAngle(double angle) {
+    if (std::abs(angle) > 2 * std::numbers::pi) {
+      throw std::invalid_argument(buildLog(std::format(
+          "The angle of a street ({}) must be between - 2 * pi and 2 * pi.", angle)));
+    }
+    m_angle = angle;
+  }
+
+  void Street::addAgent(Id agentId) {
+    if (m_waitingAgents.contains(agentId)) {
+      throw std::runtime_error(
+          buildLog(std::format("Agent with id {} is already on the street.", agentId)));
+    }
+    for (auto const& id : m_exitQueue) {
+      if (id == agentId) {
+        throw std::runtime_error(
+            buildLog(std::format("Agent with id {} is already on the street.", agentId)));
+      }
+    }
+    m_waitingAgents.insert(agentId);
+  }
+  void Street::enqueue(Id agentId) {
+    if (!m_waitingAgents.contains(agentId)) {
+      throw std::runtime_error(
+          buildLog(std::format("Agent with id {} is not on the street.", agentId)));
+    }
+    for (auto const& id : m_exitQueue) {
+      if (id == agentId) {
+        throw std::runtime_error(
+            buildLog(std::format("Agent with id {} is already on the street.", agentId)));
+      }
+    }
+    m_waitingAgents.erase(agentId);
+    m_exitQueue.push(agentId);
+  }
+  std::optional<Id> Street::dequeue() {
+    if (m_exitQueue.empty()) {
+      return std::nullopt;
+    }
+    Id id = m_exitQueue.front();
+    m_exitQueue.pop();
+    return id;
+  }
+
+  SpireStreet::SpireStreet(Id id, const Street& street)
+      : Street(id, street), m_agentCounterIn{0}, m_agentCounterOut{0} {}
+
+  SpireStreet::SpireStreet(Id id, Size capacity, double len, std::pair<Id, Id> nodePair)
+      : Street(id, capacity, len, nodePair), m_agentCounterIn{0}, m_agentCounterOut{0} {}
+
+  SpireStreet::SpireStreet(
+      Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
+      : Street(id, capacity, len, maxSpeed, nodePair),
+        m_agentCounterIn{0},
+        m_agentCounterOut{0} {}
+
+  void SpireStreet::addAgent(Id agentId) {
+    Street::addAgent(agentId);
+    ++m_agentCounterIn;
+  }
+
+  Size SpireStreet::inputCounts(bool resetValue) {
+    if (!resetValue)
+      return m_agentCounterIn;
+    Size flow = m_agentCounterIn;
+    m_agentCounterIn = 0;
+    m_agentCounterOut = 0;
+    return flow;
+  }
+  Size SpireStreet::outputCounts(bool resetValue) {
+    if (!resetValue)
+      return m_agentCounterOut;
+    Size flow = m_agentCounterOut;
+    m_agentCounterIn = 0;
+    m_agentCounterOut = 0;
+    return flow;
+  }
+  int SpireStreet::meanFlow() {
+    int flow = static_cast<int>(m_agentCounterIn) - static_cast<int>(m_agentCounterOut);
+    m_agentCounterIn = 0;
+    m_agentCounterOut = 0;
+    return flow;
+  }
+
+  std::optional<Id> SpireStreet::dequeue() {
+    std::optional<Id> id = Street::dequeue();
+    if (id.has_value()) {
+      ++m_agentCounterOut;
+    }
+    return id;
+  }
+
+};  // namespace dsm

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -47,11 +47,11 @@ namespace dsm {
     ///          existing street.
     /// @param Street The existing street
     /// @param id The new street's id
-    Street(Id id, const Street&);
+    inline Street(Id id, const Street&);
     /// @brief Construct a new Street object
     /// @param id The street's id
     /// @param nodePair The street's node pair
-    Street(Id id, std::pair<Id, Id> nodePair);
+    inline Street(Id id, std::pair<Id, Id> nodePair);
     /// @brief Construct a new Street object
     /// @details The default capacity is 1, the default length is 1, and the default speed limit is
     ///          50 km/h, i.e. 13.8888888889 m/s.
@@ -59,7 +59,7 @@ namespace dsm {
     /// @param capacity The street's capacity
     /// @param len The street's length
     /// @param nodePair The street's node pair
-    Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
+    inline Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
     /// @brief Construct a new Street object
     /// @details The default speed limit is 50 km/h, i.e. 13.8888888889 m/s.
     /// @param id The street's id
@@ -67,106 +67,106 @@ namespace dsm {
     /// @param len The street's length
     /// @param maxSpeed The street's speed limit
     /// @param nodePair The street's node pair
-    Street(Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
+    inline Street(Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
 
     virtual ~Street() = default;
 
     /// @brief Set the street's id
     /// @param id The street's id
-    void setId(Id id) { m_id = id; }
+    inline void setId(Id id) { m_id = id; }
     /// @brief Set the street's capacity
     /// @param capacity The street's capacity
-    void setCapacity(Size capacity) { m_capacity = capacity; }
+    inline void setCapacity(Size capacity) { m_capacity = capacity; }
     /// @brief Set the street's transport capacity
     /// @details The transport capacity is the maximum number of agents that can traverse the street
     ///          in a time step.
     /// @param capacity The street's transport capacity
-    void setTransportCapacity(Size capacity) { m_transportCapacity = capacity; }
+    inline void setTransportCapacity(Size capacity) { m_transportCapacity = capacity; }
     /// @brief Set the street's length
     /// @param len The street's length
     /// @throw std::invalid_argument, If the length is negative
-    void setLength(double len);
+    inline void setLength(double len);
     /// @brief Set the street's queue
     /// @param queue The street's queue
-    void setQueue(dsm::queue<Size> queue) { m_exitQueue = std::move(queue); }
+    inline void setQueue(dsm::queue<Size> queue) { m_exitQueue = std::move(queue); }
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
-    void setNodePair(Id node1, Id node2) { m_nodePair = std::make_pair(node1, node2); }
+    inline void setNodePair(Id node1, Id node2) { m_nodePair = std::make_pair(node1, node2); }
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
-    void setNodePair(const Node& node1, const Node& node2) {
+    inline void setNodePair(const Node& node1, const Node& node2) {
       m_nodePair = std::make_pair(node1.id(), node2.id());
     }
     /// @brief Set the street's node pair
     /// @param pair The street's node pair
-    void setNodePair(std::pair<Id, Id> pair) { m_nodePair = std::move(pair); }
+    inline void setNodePair(std::pair<Id, Id> pair) { m_nodePair = std::move(pair); }
     /// @brief Set the street's speed limit
     /// @param speed The street's speed limit
     /// @throw std::invalid_argument, If the speed is negative
-    void setMaxSpeed(double speed);
+    inline void setMaxSpeed(double speed);
     /// @brief Set the street's angle
     /// @param srcNode The source node of the street
     /// @param dstNode The destination node of the street
-    void setAngle(std::pair<double, double> srcNode, std::pair<double, double> dstNode);
+    inline void setAngle(std::pair<double, double> srcNode, std::pair<double, double> dstNode);
     /// @brief Set the street's angle
     /// @param angle The street's angle
     /// @throw std::invalid_argument If the angle is negative or greater than 2 * pi
-    void setAngle(double angle);
+    inline void setAngle(double angle);
 
     /// @brief Get the street's id
     /// @return Id, The street's id
-    Id id() const { return m_id; }
+    inline Id id() const { return m_id; }
     /// @brief Get the street's capacity
     /// @return Size, The street's capacity
-    Size capacity() const { return m_capacity; }
+    inline Size capacity() const { return m_capacity; }
     /// @brief Get the street's transport capacity
     /// @details The transport capacity is the maximum number of agents that can traverse the street
     ///          in a time step.
     /// @return Size, The street's transport capacity
-    Size transportCapacity() const { return m_transportCapacity; }
+    inline Size transportCapacity() const { return m_transportCapacity; }
     /// @brief Get the street's length
     /// @return double, The street's length
-    double length() const { return m_len; }
+    inline double length() const { return m_len; }
     /// @brief Get the street's waiting agents
     /// @return std::set<Id>, The street's waiting agents
-    const std::set<Id>& waitingAgents() const { return m_waitingAgents; }
+    inline const std::set<Id>& waitingAgents() const { return m_waitingAgents; }
     /// @brief Get the street's queue
     /// @return dsm::queue<Size>, The street's queue
-    const dsm::queue<Size>& queue() const { return m_exitQueue; }
+    inline const dsm::queue<Size>& queue() const { return m_exitQueue; }
     /// @brief Get the street's node pair
     /// @return std::pair<Id, Id>, The street's node pair
-    const std::pair<Id, Id>& nodePair() const { return m_nodePair; }
+    inline const std::pair<Id, Id>& nodePair() const { return m_nodePair; }
     /// @brief  Get the number of agents on the street
     /// @return Size, The number of agents on the street
-    Size nAgents() const { return m_exitQueue.size() + m_waitingAgents.size(); }
+    inline Size nAgents() const { return m_exitQueue.size() + m_waitingAgents.size(); }
     /// @brief Get the street's density in \f$m^{-1}\f$
     /// @return double, The street's density
-    double density() const { return nAgents() / m_len; }
+    inline double density() const { return nAgents() / m_len; }
     /// @brief Get the street's normalized density
     /// @return double, The street's normalized density
-    double normDensity() const { return nAgents() / static_cast<double>(m_capacity); }
+    inline double normDensity() const { return nAgents() / static_cast<double>(m_capacity); }
     /// @brief Check if the street is full
     /// @return bool, True if the street is full, false otherwise
-    bool isFull() const { return nAgents() == m_capacity; }
+    inline bool isFull() const { return nAgents() == m_capacity; }
     /// @brief Get the street's speed limit
     /// @return double, The street's speed limit
-    double maxSpeed() const { return m_maxSpeed; }
+    inline double maxSpeed() const { return m_maxSpeed; }
     /// @brief Get the street's angle
     /// @return double The street's angle
-    double angle() const { return m_angle; }
+    inline double angle() const { return m_angle; }
 
-    virtual void addAgent(Id agentId);
+    inline virtual void addAgent(Id agentId);
     /// @brief Add an agent to the street's queue
     /// @param agentId The id of the agent to add to the street's queue
     /// @throw std::runtime_error If the street's queue is full
-    void enqueue(Id agentId);
+    inline void enqueue(Id agentId);
     /// @brief Remove an agent from the street's queue
-    virtual std::optional<Id> dequeue();
+    inline virtual std::optional<Id> dequeue();
     /// @brief Check if the street is a spire
     /// @return bool True if the street is a spire, false otherwise
-    virtual bool isSpire() const { return false; };
+    inline virtual bool isSpire() const { return false; };
   };
 
   Street::Street(Id id, const Street& street)
@@ -288,47 +288,47 @@ namespace dsm {
     /// @brief Construct a new SpireStreet object starting from an existing street
     /// @param id The street's id
     /// @param street The existing street
-    SpireStreet(Id id, const Street& street);
+    inline SpireStreet(Id id, const Street& street);
     /// @brief Construct a new SpireStreet object
     /// @param id The street's id
     /// @param capacity The street's capacity
     /// @param len The street's length
     /// @param nodePair The street's node pair
-    SpireStreet(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
+    inline SpireStreet(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
     /// @brief Construct a new SpireStreet object
     /// @param id The street's id
     /// @param capacity The street's capacity
     /// @param len The street's length
     /// @param maxSpeed The street's speed limit
     /// @param nodePair The street's node pair
-    SpireStreet(
+    inline SpireStreet(
         Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
     ~SpireStreet() = default;
 
     /// @brief Add an agent to the street's queue
     /// @param agentId The id of the agent to add to the street's queue
     /// @throw std::runtime_error If the street's queue is full
-    void addAgent(Id agentId) override;
+    inline void addAgent(Id agentId) override;
 
     /// @brief Get the input counts of the street
     /// @param resetValue If true, the counter is reset to 0 together with the output counter.
     /// @return Size The input counts of the street
-    Size inputCounts(bool resetValue = false);
+    inline Size inputCounts(bool resetValue = false);
     /// @brief Get the output counts of the street
     /// @param resetValue If true, the counter is reset to 0 together with the input counter.
     /// @return Size The output counts of the street
-    Size outputCounts(bool resetValue = false);
+    inline Size outputCounts(bool resetValue = false);
     /// @brief Get the mean flow of the street
     /// @return int The flow of the street, i.e. the difference between input and output flows
     /// @details Once the flow is retrieved, bothh the input and output flows are reset to 0.
     ///     Notice that this flow is positive iff the input flow is greater than the output flow.
-    int meanFlow();
+    inline int meanFlow();
     /// @brief Remove an agent from the street's queue
     /// @return std::optional<Id> The id of the agent removed from the street's queue
-    std::optional<Id> dequeue() override;
+    inline std::optional<Id> dequeue() override;
     /// @brief Check if the street is a spire
     /// @return bool True if the street is a spire, false otherwise
-    bool isSpire() const override { return true; };
+    inline bool isSpire() const override { return true; };
   };
 
   SpireStreet::SpireStreet(Id id, const Street& street)

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -23,13 +23,12 @@
 #include "../utility/TypeTraits/is_numeric.hpp"
 #include "../utility/queue.hpp"
 #include "../utility/Logger.hpp"
+#include "../utility/Typedef.hpp"
 
 namespace dsm {
   /// @brief The Street class represents a street in the network.
   /// @tparam Id, The type of the street's id. It must be an unsigned integral type.
   /// @tparam Size, The type of the street's capacity. It must be an unsigned integral type.
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Street {
   private:
     dsm::queue<Size> m_exitQueue;
@@ -48,7 +47,7 @@ namespace dsm {
     ///          existing street.
     /// @param Street The existing street
     /// @param id The new street's id
-    Street(Id id, const Street<Id, Size>&);
+    Street(Id id, const Street&);
     /// @brief Construct a new Street object
     /// @param id The street's id
     /// @param nodePair The street's node pair
@@ -97,7 +96,7 @@ namespace dsm {
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
-    void setNodePair(const Node<Id, Size>& node1, const Node<Id, Size>& node2) {
+    void setNodePair(const Node& node1, const Node& node2) {
       m_nodePair = std::make_pair(node1.id(), node2.id());
     }
     /// @brief Set the street's node pair
@@ -170,9 +169,7 @@ namespace dsm {
     virtual bool isSpire() const { return false; };
   };
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(Id id, const Street<Id, Size>& street)
+  Street::Street(Id id, const Street& street)
       : m_nodePair{street.nodePair()},
         m_len{street.length()},
         m_maxSpeed{street.maxSpeed()},
@@ -181,9 +178,7 @@ namespace dsm {
         m_capacity{street.capacity()},
         m_transportCapacity{street.transportCapacity()} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(Id index, std::pair<Id, Id> pair)
+  Street::Street(Id index, std::pair<Id, Id> pair)
       : m_nodePair{std::move(pair)},
         m_len{1.},
         m_maxSpeed{13.8888888889},
@@ -192,9 +187,7 @@ namespace dsm {
         m_capacity{1},
         m_transportCapacity{std::numeric_limits<Size>::max()} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair)
+  Street::Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair)
       : m_nodePair{std::move(nodePair)},
         m_len{len},
         m_maxSpeed{13.8888888889},
@@ -203,9 +196,7 @@ namespace dsm {
         m_capacity{capacity},
         m_transportCapacity{std::numeric_limits<Size>::max()} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Street<Id, Size>::Street(
+  Street::Street(
       Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
       : m_nodePair{std::move(nodePair)},
         m_len{len},
@@ -216,27 +207,21 @@ namespace dsm {
     this->setMaxSpeed(maxSpeed);
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::setLength(double len) {
+  void Street::setLength(double len) {
     if (len < 0.) {
       throw std::invalid_argument(
           buildLog(std::format("The length of a street ({}) cannot be negative.", len)));
     }
     m_len = len;
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::setMaxSpeed(double speed) {
+  void Street::setMaxSpeed(double speed) {
     if (speed < 0.) {
       throw std::invalid_argument(buildLog(
           std::format("The maximum speed of a street ({}) cannot be negative.", speed)));
     }
     m_maxSpeed = speed;
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::setAngle(std::pair<double, double> srcNode,
+  void Street::setAngle(std::pair<double, double> srcNode,
                                   std::pair<double, double> dstNode) {
     // N.B.: lat, lon <==> y, x
     double delta_y{dstNode.first - srcNode.first};
@@ -247,9 +232,7 @@ namespace dsm {
     }
     this->setAngle(angle);
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::setAngle(double angle) {
+  void Street::setAngle(double angle) {
     if (std::abs(angle) > 2 * std::numbers::pi) {
       throw std::invalid_argument(buildLog(std::format(
           "The angle of a street ({}) must be between - 2 * pi and 2 * pi.", angle)));
@@ -257,9 +240,7 @@ namespace dsm {
     m_angle = angle;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::addAgent(Id agentId) {
+  void Street::addAgent(Id agentId) {
     if (m_waitingAgents.contains(agentId)) {
       throw std::runtime_error(
           buildLog(std::format("Agent with id {} is already on the street.", agentId)));
@@ -272,9 +253,7 @@ namespace dsm {
     }
     m_waitingAgents.insert(agentId);
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void Street<Id, Size>::enqueue(Id agentId) {
+  void Street::enqueue(Id agentId) {
     if (!m_waitingAgents.contains(agentId)) {
       throw std::runtime_error(
           buildLog(std::format("Agent with id {} is not on the street.", agentId)));
@@ -288,9 +267,7 @@ namespace dsm {
     m_waitingAgents.erase(agentId);
     m_exitQueue.push(agentId);
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  std::optional<Id> Street<Id, Size>::dequeue() {
+  std::optional<Id> Street::dequeue() {
     if (m_exitQueue.empty()) {
       return std::nullopt;
     }
@@ -302,9 +279,7 @@ namespace dsm {
   /// @brief The SpireStreet class represents a street which is able to count agent flows in both input and output.
   /// @tparam Id The type of the street's id
   /// @tparam Size The type of the street's capacity
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  class SpireStreet : public Street<Id, Size> {
+  class SpireStreet : public Street {
   private:
     Size m_agentCounterIn;
     Size m_agentCounterOut;
@@ -313,7 +288,7 @@ namespace dsm {
     /// @brief Construct a new SpireStreet object starting from an existing street
     /// @param id The street's id
     /// @param street The existing street
-    SpireStreet(Id id, const Street<Id, Size>& street);
+    SpireStreet(Id id, const Street& street);
     /// @brief Construct a new SpireStreet object
     /// @param id The street's id
     /// @param capacity The street's capacity
@@ -356,39 +331,29 @@ namespace dsm {
     bool isSpire() const override { return true; };
   };
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  SpireStreet<Id, Size>::SpireStreet(Id id, const Street<Id, Size>& street)
-      : Street<Id, Size>(id, street), m_agentCounterIn{0}, m_agentCounterOut{0} {}
+  SpireStreet::SpireStreet(Id id, const Street& street)
+      : Street(id, street), m_agentCounterIn{0}, m_agentCounterOut{0} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  SpireStreet<Id, Size>::SpireStreet(Id id,
+  SpireStreet::SpireStreet(Id id,
                                      Size capacity,
                                      double len,
                                      std::pair<Id, Id> nodePair)
-      : Street<Id, Size>(id, capacity, len, nodePair),
+      : Street(id, capacity, len, nodePair),
         m_agentCounterIn{0},
         m_agentCounterOut{0} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  SpireStreet<Id, Size>::SpireStreet(
+  SpireStreet::SpireStreet(
       Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
-      : Street<Id, Size>(id, capacity, len, maxSpeed, nodePair),
+      : Street(id, capacity, len, maxSpeed, nodePair),
         m_agentCounterIn{0},
         m_agentCounterOut{0} {}
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  void SpireStreet<Id, Size>::addAgent(Id agentId) {
-    Street<Id, Size>::addAgent(agentId);
+  void SpireStreet::addAgent(Id agentId) {
+    Street::addAgent(agentId);
     ++m_agentCounterIn;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Size SpireStreet<Id, Size>::inputCounts(bool resetValue) {
+  Size SpireStreet::inputCounts(bool resetValue) {
     if (!resetValue)
       return m_agentCounterIn;
     Size flow = m_agentCounterIn;
@@ -396,9 +361,7 @@ namespace dsm {
     m_agentCounterOut = 0;
     return flow;
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  Size SpireStreet<Id, Size>::outputCounts(bool resetValue) {
+  Size SpireStreet::outputCounts(bool resetValue) {
     if (!resetValue)
       return m_agentCounterOut;
     Size flow = m_agentCounterOut;
@@ -406,19 +369,15 @@ namespace dsm {
     m_agentCounterOut = 0;
     return flow;
   }
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  int SpireStreet<Id, Size>::meanFlow() {
+  int SpireStreet::meanFlow() {
     int flow = static_cast<int>(m_agentCounterIn) - static_cast<int>(m_agentCounterOut);
     m_agentCounterIn = 0;
     m_agentCounterOut = 0;
     return flow;
   }
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
-  std::optional<Id> SpireStreet<Id, Size>::dequeue() {
-    std::optional<Id> id = Street<Id, Size>::dequeue();
+  std::optional<Id> SpireStreet::dequeue() {
+    std::optional<Id> id = Street::dequeue();
     if (id.has_value()) {
       ++m_agentCounterOut;
     }

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -67,8 +67,7 @@ namespace dsm {
     /// @param len The street's length
     /// @param maxSpeed The street's speed limit
     /// @param nodePair The street's node pair
-    Street(
-        Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
+    Street(Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
 
     virtual ~Street() = default;
 
@@ -93,9 +92,7 @@ namespace dsm {
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
-    void setNodePair(Id node1, Id node2) {
-      m_nodePair = std::make_pair(node1, node2);
-    }
+    void setNodePair(Id node1, Id node2) { m_nodePair = std::make_pair(node1, node2); }
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
@@ -112,8 +109,7 @@ namespace dsm {
     /// @brief Set the street's angle
     /// @param srcNode The source node of the street
     /// @param dstNode The destination node of the street
-    void setAngle(std::pair<double, double> srcNode,
-                         std::pair<double, double> dstNode);
+    void setAngle(std::pair<double, double> srcNode, std::pair<double, double> dstNode);
     /// @brief Set the street's angle
     /// @param angle The street's angle
     /// @throw std::invalid_argument If the angle is negative or greater than 2 * pi
@@ -150,9 +146,7 @@ namespace dsm {
     double density() const { return nAgents() / m_len; }
     /// @brief Get the street's normalized density
     /// @return double, The street's normalized density
-    double normDensity() const {
-      return nAgents() / static_cast<double>(m_capacity);
-    }
+    double normDensity() const { return nAgents() / static_cast<double>(m_capacity); }
     /// @brief Check if the street is full
     /// @return bool, True if the street is full, false otherwise
     bool isFull() const { return nAgents() == m_capacity; }
@@ -174,7 +168,6 @@ namespace dsm {
     /// @return bool True if the street is a spire, false otherwise
     virtual bool isSpire() const { return false; };
   };
-
 
   /// @brief The SpireStreet class represents a street which is able to count agent flows in both input and output.
   /// @tparam Id The type of the street's id
@@ -230,5 +223,5 @@ namespace dsm {
     /// @return bool True if the street is a spire, false otherwise
     bool isSpire() const override { return true; };
   };
-  
+
 };  // namespace dsm

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -47,11 +47,11 @@ namespace dsm {
     ///          existing street.
     /// @param Street The existing street
     /// @param id The new street's id
-    inline Street(Id id, const Street&);
+    Street(Id id, const Street&);
     /// @brief Construct a new Street object
     /// @param id The street's id
     /// @param nodePair The street's node pair
-    inline Street(Id id, std::pair<Id, Id> nodePair);
+    Street(Id id, std::pair<Id, Id> nodePair);
     /// @brief Construct a new Street object
     /// @details The default capacity is 1, the default length is 1, and the default speed limit is
     ///          50 km/h, i.e. 13.8888888889 m/s.
@@ -59,7 +59,7 @@ namespace dsm {
     /// @param capacity The street's capacity
     /// @param len The street's length
     /// @param nodePair The street's node pair
-    inline Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
+    Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
     /// @brief Construct a new Street object
     /// @details The default speed limit is 50 km/h, i.e. 13.8888888889 m/s.
     /// @param id The street's id
@@ -67,214 +67,114 @@ namespace dsm {
     /// @param len The street's length
     /// @param maxSpeed The street's speed limit
     /// @param nodePair The street's node pair
-    inline Street(Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
+    Street(
+        Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
 
     virtual ~Street() = default;
 
     /// @brief Set the street's id
     /// @param id The street's id
-    inline void setId(Id id) { m_id = id; }
+    void setId(Id id) { m_id = id; }
     /// @brief Set the street's capacity
     /// @param capacity The street's capacity
-    inline void setCapacity(Size capacity) { m_capacity = capacity; }
+    void setCapacity(Size capacity) { m_capacity = capacity; }
     /// @brief Set the street's transport capacity
     /// @details The transport capacity is the maximum number of agents that can traverse the street
     ///          in a time step.
     /// @param capacity The street's transport capacity
-    inline void setTransportCapacity(Size capacity) { m_transportCapacity = capacity; }
+    void setTransportCapacity(Size capacity) { m_transportCapacity = capacity; }
     /// @brief Set the street's length
     /// @param len The street's length
     /// @throw std::invalid_argument, If the length is negative
-    inline void setLength(double len);
+    void setLength(double len);
     /// @brief Set the street's queue
     /// @param queue The street's queue
-    inline void setQueue(dsm::queue<Size> queue) { m_exitQueue = std::move(queue); }
+    void setQueue(dsm::queue<Size> queue) { m_exitQueue = std::move(queue); }
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
-    inline void setNodePair(Id node1, Id node2) { m_nodePair = std::make_pair(node1, node2); }
+    void setNodePair(Id node1, Id node2) {
+      m_nodePair = std::make_pair(node1, node2);
+    }
     /// @brief Set the street's node pair
     /// @param node1 The source node of the street
     /// @param node2 The destination node of the street
-    inline void setNodePair(const Node& node1, const Node& node2) {
+    void setNodePair(const Node& node1, const Node& node2) {
       m_nodePair = std::make_pair(node1.id(), node2.id());
     }
     /// @brief Set the street's node pair
     /// @param pair The street's node pair
-    inline void setNodePair(std::pair<Id, Id> pair) { m_nodePair = std::move(pair); }
+    void setNodePair(std::pair<Id, Id> pair) { m_nodePair = std::move(pair); }
     /// @brief Set the street's speed limit
     /// @param speed The street's speed limit
     /// @throw std::invalid_argument, If the speed is negative
-    inline void setMaxSpeed(double speed);
+    void setMaxSpeed(double speed);
     /// @brief Set the street's angle
     /// @param srcNode The source node of the street
     /// @param dstNode The destination node of the street
-    inline void setAngle(std::pair<double, double> srcNode, std::pair<double, double> dstNode);
+    void setAngle(std::pair<double, double> srcNode,
+                         std::pair<double, double> dstNode);
     /// @brief Set the street's angle
     /// @param angle The street's angle
     /// @throw std::invalid_argument If the angle is negative or greater than 2 * pi
-    inline void setAngle(double angle);
+    void setAngle(double angle);
 
     /// @brief Get the street's id
     /// @return Id, The street's id
-    inline Id id() const { return m_id; }
+    Id id() const { return m_id; }
     /// @brief Get the street's capacity
     /// @return Size, The street's capacity
-    inline Size capacity() const { return m_capacity; }
+    Size capacity() const { return m_capacity; }
     /// @brief Get the street's transport capacity
     /// @details The transport capacity is the maximum number of agents that can traverse the street
     ///          in a time step.
     /// @return Size, The street's transport capacity
-    inline Size transportCapacity() const { return m_transportCapacity; }
+    Size transportCapacity() const { return m_transportCapacity; }
     /// @brief Get the street's length
     /// @return double, The street's length
-    inline double length() const { return m_len; }
+    double length() const { return m_len; }
     /// @brief Get the street's waiting agents
     /// @return std::set<Id>, The street's waiting agents
-    inline const std::set<Id>& waitingAgents() const { return m_waitingAgents; }
+    const std::set<Id>& waitingAgents() const { return m_waitingAgents; }
     /// @brief Get the street's queue
     /// @return dsm::queue<Size>, The street's queue
-    inline const dsm::queue<Size>& queue() const { return m_exitQueue; }
+    const dsm::queue<Size>& queue() const { return m_exitQueue; }
     /// @brief Get the street's node pair
     /// @return std::pair<Id, Id>, The street's node pair
-    inline const std::pair<Id, Id>& nodePair() const { return m_nodePair; }
+    const std::pair<Id, Id>& nodePair() const { return m_nodePair; }
     /// @brief  Get the number of agents on the street
     /// @return Size, The number of agents on the street
-    inline Size nAgents() const { return m_exitQueue.size() + m_waitingAgents.size(); }
+    Size nAgents() const { return m_exitQueue.size() + m_waitingAgents.size(); }
     /// @brief Get the street's density in \f$m^{-1}\f$
     /// @return double, The street's density
-    inline double density() const { return nAgents() / m_len; }
+    double density() const { return nAgents() / m_len; }
     /// @brief Get the street's normalized density
     /// @return double, The street's normalized density
-    inline double normDensity() const { return nAgents() / static_cast<double>(m_capacity); }
+    double normDensity() const {
+      return nAgents() / static_cast<double>(m_capacity);
+    }
     /// @brief Check if the street is full
     /// @return bool, True if the street is full, false otherwise
-    inline bool isFull() const { return nAgents() == m_capacity; }
+    bool isFull() const { return nAgents() == m_capacity; }
     /// @brief Get the street's speed limit
     /// @return double, The street's speed limit
-    inline double maxSpeed() const { return m_maxSpeed; }
+    double maxSpeed() const { return m_maxSpeed; }
     /// @brief Get the street's angle
     /// @return double The street's angle
-    inline double angle() const { return m_angle; }
+    double angle() const { return m_angle; }
 
-    inline virtual void addAgent(Id agentId);
+    virtual void addAgent(Id agentId);
     /// @brief Add an agent to the street's queue
     /// @param agentId The id of the agent to add to the street's queue
     /// @throw std::runtime_error If the street's queue is full
-    inline void enqueue(Id agentId);
+    void enqueue(Id agentId);
     /// @brief Remove an agent from the street's queue
-    inline virtual std::optional<Id> dequeue();
+    virtual std::optional<Id> dequeue();
     /// @brief Check if the street is a spire
     /// @return bool True if the street is a spire, false otherwise
-    inline virtual bool isSpire() const { return false; };
+    virtual bool isSpire() const { return false; };
   };
 
-  Street::Street(Id id, const Street& street)
-      : m_nodePair{street.nodePair()},
-        m_len{street.length()},
-        m_maxSpeed{street.maxSpeed()},
-        m_angle{street.angle()},
-        m_id{id},
-        m_capacity{street.capacity()},
-        m_transportCapacity{street.transportCapacity()} {}
-
-  Street::Street(Id index, std::pair<Id, Id> pair)
-      : m_nodePair{std::move(pair)},
-        m_len{1.},
-        m_maxSpeed{13.8888888889},
-        m_angle{0.},
-        m_id{index},
-        m_capacity{1},
-        m_transportCapacity{std::numeric_limits<Size>::max()} {}
-
-  Street::Street(Id id, Size capacity, double len, std::pair<Id, Id> nodePair)
-      : m_nodePair{std::move(nodePair)},
-        m_len{len},
-        m_maxSpeed{13.8888888889},
-        m_angle{0.},
-        m_id{id},
-        m_capacity{capacity},
-        m_transportCapacity{std::numeric_limits<Size>::max()} {}
-
-  Street::Street(
-      Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
-      : m_nodePair{std::move(nodePair)},
-        m_len{len},
-        m_angle{0.},
-        m_id{id},
-        m_capacity{capacity},
-        m_transportCapacity{std::numeric_limits<Size>::max()} {
-    this->setMaxSpeed(maxSpeed);
-  }
-
-  void Street::setLength(double len) {
-    if (len < 0.) {
-      throw std::invalid_argument(
-          buildLog(std::format("The length of a street ({}) cannot be negative.", len)));
-    }
-    m_len = len;
-  }
-  void Street::setMaxSpeed(double speed) {
-    if (speed < 0.) {
-      throw std::invalid_argument(buildLog(
-          std::format("The maximum speed of a street ({}) cannot be negative.", speed)));
-    }
-    m_maxSpeed = speed;
-  }
-  void Street::setAngle(std::pair<double, double> srcNode,
-                                  std::pair<double, double> dstNode) {
-    // N.B.: lat, lon <==> y, x
-    double delta_y{dstNode.first - srcNode.first};
-    double delta_x{dstNode.second - srcNode.second};
-    double angle{std::atan2(delta_y, delta_x)};
-    if (angle < 0.) {
-      angle += 2 * std::numbers::pi;
-    }
-    this->setAngle(angle);
-  }
-  void Street::setAngle(double angle) {
-    if (std::abs(angle) > 2 * std::numbers::pi) {
-      throw std::invalid_argument(buildLog(std::format(
-          "The angle of a street ({}) must be between - 2 * pi and 2 * pi.", angle)));
-    }
-    m_angle = angle;
-  }
-
-  void Street::addAgent(Id agentId) {
-    if (m_waitingAgents.contains(agentId)) {
-      throw std::runtime_error(
-          buildLog(std::format("Agent with id {} is already on the street.", agentId)));
-    }
-    for (auto const& id : m_exitQueue) {
-      if (id == agentId) {
-        throw std::runtime_error(
-            buildLog(std::format("Agent with id {} is already on the street.", agentId)));
-      }
-    }
-    m_waitingAgents.insert(agentId);
-  }
-  void Street::enqueue(Id agentId) {
-    if (!m_waitingAgents.contains(agentId)) {
-      throw std::runtime_error(
-          buildLog(std::format("Agent with id {} is not on the street.", agentId)));
-    }
-    for (auto const& id : m_exitQueue) {
-      if (id == agentId) {
-        throw std::runtime_error(
-            buildLog(std::format("Agent with id {} is already on the street.", agentId)));
-      }
-    }
-    m_waitingAgents.erase(agentId);
-    m_exitQueue.push(agentId);
-  }
-  std::optional<Id> Street::dequeue() {
-    if (m_exitQueue.empty()) {
-      return std::nullopt;
-    }
-    Id id = m_exitQueue.front();
-    m_exitQueue.pop();
-    return id;
-  }
 
   /// @brief The SpireStreet class represents a street which is able to count agent flows in both input and output.
   /// @tparam Id The type of the street's id
@@ -288,100 +188,47 @@ namespace dsm {
     /// @brief Construct a new SpireStreet object starting from an existing street
     /// @param id The street's id
     /// @param street The existing street
-    inline SpireStreet(Id id, const Street& street);
+    SpireStreet(Id id, const Street& street);
     /// @brief Construct a new SpireStreet object
     /// @param id The street's id
     /// @param capacity The street's capacity
     /// @param len The street's length
     /// @param nodePair The street's node pair
-    inline SpireStreet(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
+    SpireStreet(Id id, Size capacity, double len, std::pair<Id, Id> nodePair);
     /// @brief Construct a new SpireStreet object
     /// @param id The street's id
     /// @param capacity The street's capacity
     /// @param len The street's length
     /// @param maxSpeed The street's speed limit
     /// @param nodePair The street's node pair
-    inline SpireStreet(
+    SpireStreet(
         Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair);
     ~SpireStreet() = default;
 
     /// @brief Add an agent to the street's queue
     /// @param agentId The id of the agent to add to the street's queue
     /// @throw std::runtime_error If the street's queue is full
-    inline void addAgent(Id agentId) override;
+    void addAgent(Id agentId) override;
 
     /// @brief Get the input counts of the street
     /// @param resetValue If true, the counter is reset to 0 together with the output counter.
     /// @return Size The input counts of the street
-    inline Size inputCounts(bool resetValue = false);
+    Size inputCounts(bool resetValue = false);
     /// @brief Get the output counts of the street
     /// @param resetValue If true, the counter is reset to 0 together with the input counter.
     /// @return Size The output counts of the street
-    inline Size outputCounts(bool resetValue = false);
+    Size outputCounts(bool resetValue = false);
     /// @brief Get the mean flow of the street
     /// @return int The flow of the street, i.e. the difference between input and output flows
     /// @details Once the flow is retrieved, bothh the input and output flows are reset to 0.
     ///     Notice that this flow is positive iff the input flow is greater than the output flow.
-    inline int meanFlow();
+    int meanFlow();
     /// @brief Remove an agent from the street's queue
     /// @return std::optional<Id> The id of the agent removed from the street's queue
-    inline std::optional<Id> dequeue() override;
+    std::optional<Id> dequeue() override;
     /// @brief Check if the street is a spire
     /// @return bool True if the street is a spire, false otherwise
-    inline bool isSpire() const override { return true; };
+    bool isSpire() const override { return true; };
   };
-
-  SpireStreet::SpireStreet(Id id, const Street& street)
-      : Street(id, street), m_agentCounterIn{0}, m_agentCounterOut{0} {}
-
-  SpireStreet::SpireStreet(Id id,
-                                     Size capacity,
-                                     double len,
-                                     std::pair<Id, Id> nodePair)
-      : Street(id, capacity, len, nodePair),
-        m_agentCounterIn{0},
-        m_agentCounterOut{0} {}
-
-  SpireStreet::SpireStreet(
-      Id id, Size capacity, double len, double maxSpeed, std::pair<Id, Id> nodePair)
-      : Street(id, capacity, len, maxSpeed, nodePair),
-        m_agentCounterIn{0},
-        m_agentCounterOut{0} {}
-
-  void SpireStreet::addAgent(Id agentId) {
-    Street::addAgent(agentId);
-    ++m_agentCounterIn;
-  }
-
-  Size SpireStreet::inputCounts(bool resetValue) {
-    if (!resetValue)
-      return m_agentCounterIn;
-    Size flow = m_agentCounterIn;
-    m_agentCounterIn = 0;
-    m_agentCounterOut = 0;
-    return flow;
-  }
-  Size SpireStreet::outputCounts(bool resetValue) {
-    if (!resetValue)
-      return m_agentCounterOut;
-    Size flow = m_agentCounterOut;
-    m_agentCounterIn = 0;
-    m_agentCounterOut = 0;
-    return flow;
-  }
-  int SpireStreet::meanFlow() {
-    int flow = static_cast<int>(m_agentCounterIn) - static_cast<int>(m_agentCounterOut);
-    m_agentCounterIn = 0;
-    m_agentCounterOut = 0;
-    return flow;
-  }
-
-  std::optional<Id> SpireStreet::dequeue() {
-    std::optional<Id> id = Street::dequeue();
-    if (id.has_value()) {
-      ++m_agentCounterOut;
-    }
-    return id;
-  }
-
+  
 };  // namespace dsm

--- a/src/dsm/utility/DijkstraResult.hpp
+++ b/src/dsm/utility/DijkstraResult.hpp
@@ -6,12 +6,12 @@
 
 #pragma once
 
+#include "Typedef.hpp"
+
 namespace dsm {
 
   /// @brief The DijkstraResult class represents the result of a Dijkstra algorithm.
   /// @tparam Id, The type of the graph's id. Must be an unsigned integral type.
-  template <typename Id>
-    requires(std::unsigned_integral<Id>)
   class DijkstraResult {
   private:
     std::vector<Id> m_path;

--- a/src/dsm/utility/TypeTraits/is_agent.hpp
+++ b/src/dsm/utility/TypeTraits/is_agent.hpp
@@ -7,20 +7,19 @@
 #include "is_numeric.hpp"
 
 namespace dsm {
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
-             is_numeric_v<Delay>)
+  template <typename Delay>
+    requires(is_numeric_v<Delay>)
   class Agent;
 
   // define is_node type trait
   template <typename T>
   struct is_agent : std::false_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_agent<Agent<Id, Size, Delay>> : std::true_type {};
+  template <typename Delay>
+  struct is_agent<Agent<Delay>> : std::true_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_agent<std::unique_ptr<Agent<Id, Size, Delay>>> : std::true_type {};
+  template <typename Delay>
+  struct is_agent<std::unique_ptr<Agent<Delay>>> : std::true_type {};
 
   template <typename T>
   inline constexpr bool is_agent_v = is_agent<T>::value;

--- a/src/dsm/utility/TypeTraits/is_itinerary.hpp
+++ b/src/dsm/utility/TypeTraits/is_itinerary.hpp
@@ -6,19 +6,17 @@
 #include <type_traits>
 
 namespace dsm {
-  template <typename Id>
-    requires(std::unsigned_integral<Id>)
   class Itinerary;
 
   // define is_node type trait
   template <typename T>
   struct is_itinerary : std::false_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_itinerary<Agent<Id, Size, Delay>> : std::true_type {};
+  template <typename Delay>
+  struct is_itinerary<Agent<Delay>> : std::true_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_itinerary<std::unique_ptr<Agent<Id, Size, Delay>>> : std::true_type {};
+  template <typename Delay>
+  struct is_itinerary<std::unique_ptr<Agent<Delay>>> : std::true_type {};
 
   template <typename T>
   inline constexpr bool is_itinerary_v = is_itinerary<T>::value;

--- a/src/dsm/utility/TypeTraits/is_node.hpp
+++ b/src/dsm/utility/TypeTraits/is_node.hpp
@@ -11,8 +11,7 @@ namespace dsm {
   class Intersection;
 
   template <typename Delay>
-    requires(
-             std::unsigned_integral<Delay>)
+    requires(std::unsigned_integral<Delay>)
   class TrafficLight;
 
   class Roundabout;

--- a/src/dsm/utility/TypeTraits/is_node.hpp
+++ b/src/dsm/utility/TypeTraits/is_node.hpp
@@ -6,25 +6,23 @@
 #include <type_traits>
 
 namespace dsm {
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Node;
 
   // define is_node type trait
   template <typename T>
   struct is_node : std::false_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<Node<Id, Size>> : std::true_type {};
+  template <>
+  struct is_node<Node> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<const Node<Id, Size>> : std::true_type {};
+  template <>
+  struct is_node<const Node> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<const Node<Id, Size>&> : std::true_type {};
+  template <>
+  struct is_node<const Node&> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<std::unique_ptr<Node<Id, Size>>> : std::true_type {};
+  template <>
+  struct is_node<std::unique_ptr<Node>> : std::true_type {};
 
   template <typename T>
   inline constexpr bool is_node_v = is_node<T>::value;

--- a/src/dsm/utility/TypeTraits/is_node.hpp
+++ b/src/dsm/utility/TypeTraits/is_node.hpp
@@ -8,17 +8,13 @@
 namespace dsm {
   class Node;
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Intersection;
 
-  template <typename Id, typename Size, typename Delay>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size> &&
+  template <typename Delay>
+    requires(
              std::unsigned_integral<Delay>)
   class TrafficLight;
 
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Roundabout;
 
   // define is_node type trait
@@ -38,41 +34,41 @@ namespace dsm {
   struct is_node<std::unique_ptr<Node>> : std::true_type {};
 
   // TODO: this is bad, I'll rework the type-traits
-  template <typename Id, typename Size>
-  struct is_node<Intersection<Id, Size>> : std::true_type {};
+  template <>
+  struct is_node<Intersection> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<const Intersection<Id, Size>> : std::true_type {};
+  template <>
+  struct is_node<const Intersection> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<const Intersection<Id, Size>&> : std::true_type {};
+  template <>
+  struct is_node<const Intersection&> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<std::unique_ptr<Intersection<Id, Size>>> : std::true_type {};
+  template <>
+  struct is_node<std::unique_ptr<Intersection>> : std::true_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_node<TrafficLight<Id, Size, Delay>> : std::true_type {};
+  template <typename Delay>
+  struct is_node<TrafficLight<Delay>> : std::true_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_node<const TrafficLight<Id, Size, Delay>> : std::true_type {};
+  template <typename Delay>
+  struct is_node<const TrafficLight<Delay>> : std::true_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_node<const TrafficLight<Id, Size, Delay>&> : std::true_type {};
+  template <typename Delay>
+  struct is_node<const TrafficLight<Delay>&> : std::true_type {};
 
-  template <typename Id, typename Size, typename Delay>
-  struct is_node<std::unique_ptr<TrafficLight<Id, Size, Delay>>> : std::true_type {};
+  template <typename Delay>
+  struct is_node<std::unique_ptr<TrafficLight<Delay>>> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<Roundabout<Id, Size>> : std::true_type {};
+  template <>
+  struct is_node<Roundabout> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<const Roundabout<Id, Size>> : std::true_type {};
+  template <>
+  struct is_node<const Roundabout> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<const Roundabout<Id, Size>&> : std::true_type {};
+  template <>
+  struct is_node<const Roundabout&> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_node<std::unique_ptr<Roundabout<Id, Size>>> : std::true_type {};
+  template <>
+  struct is_node<std::unique_ptr<Roundabout>> : std::true_type {};
 
   template <typename T>
   inline constexpr bool is_node_v = is_node<T>::value;

--- a/src/dsm/utility/TypeTraits/is_street.hpp
+++ b/src/dsm/utility/TypeTraits/is_street.hpp
@@ -6,25 +6,23 @@
 #include <type_traits>
 
 namespace dsm {
-  template <typename Id, typename Size>
-    requires(std::unsigned_integral<Id> && std::unsigned_integral<Size>)
   class Street;
 
   // define the is_street type trait
   template <typename T>
   struct is_street : std::false_type {};
 
-  template <typename Id, typename Size>
-  struct is_street<Street<Id, Size>> : std::true_type {};
+  template <>
+  struct is_street<Street> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_street<const Street<Id, Size>> : std::true_type {};
+  template <>
+  struct is_street<const Street> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_street<const Street<Id, Size>&> : std::true_type {};
+  template <>
+  struct is_street<const Street&> : std::true_type {};
 
-  template <typename Id, typename Size>
-  struct is_street<std::unique_ptr<Street<Id, Size>>> : std::true_type {};
+  template <>
+  struct is_street<std::unique_ptr<Street>> : std::true_type {};
 
   template <typename T>
   inline constexpr bool is_street_v = is_street<T>::value;

--- a/src/dsm/utility/Typedef.hpp
+++ b/src/dsm/utility/Typedef.hpp
@@ -8,4 +8,4 @@ namespace dsm {
   using Id = uint32_t;
   using Size = uint32_t;
 
-};
+};  // namespace dsm

--- a/src/dsm/utility/Typedef.hpp
+++ b/src/dsm/utility/Typedef.hpp
@@ -1,0 +1,9 @@
+
+#pragma once
+
+namespace dsm {
+
+  using Id = uint32_t;
+  using Size = uint32_t;
+
+};

--- a/src/dsm/utility/Typedef.hpp
+++ b/src/dsm/utility/Typedef.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace dsm {
 
   using Id = uint32_t;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,9 @@ if(NOT doctest_POPULATED)
 endif()
 
 # add as executable all cpp files into '.' folder
-file(GLOB SOURCES "*.cpp")
+file(GLOB TEST_SOURCES "*.cpp")
+file(GLOB SRC_SOURCES "../src/dsm/headers/*.cpp")
+list(APPEND SOURCES ${TEST_SOURCES} ${SRC_SOURCES})
 
 # Define the executable
 add_executable(dsm_tests.out ${SOURCES})

--- a/test/Test_agent.cpp
+++ b/test/Test_agent.cpp
@@ -5,8 +5,8 @@
 
 #include "doctest.h"
 
-using Agent = dsm::Agent<uint16_t, uint16_t, uint16_t>;
-using Itinerary = dsm::Itinerary<uint16_t>;
+using Agent = dsm::Agent<uint16_t>;
+using Itinerary = dsm::Itinerary;
 
 TEST_CASE("Agent") {
   SUBCASE("Constructors") {

--- a/test/Test_agent.cpp
+++ b/test/Test_agent.cpp
@@ -3,10 +3,10 @@
 #include "Agent.hpp"
 #include "Itinerary.hpp"
 
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
 using Agent = dsm::Agent<uint16_t>;
-using Itinerary = dsm::Itinerary;
 
 TEST_CASE("Agent") {
   SUBCASE("Constructors") {

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -18,6 +18,7 @@ using Itinerary = dsm::Itinerary;
 using Intersection = dsm::Intersection;
 using TrafficLight = dsm::TrafficLight<uint16_t>;
 using Roundabout = dsm::Roundabout;
+using Measurement = dsm::Measurement<float>;
 
 TEST_CASE("Measurement") {
   SUBCASE("STL vector") {

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -8,16 +8,16 @@
 
 #include "doctest.h"
 
-using Dynamics = dsm::FirstOrderDynamics<uint16_t, uint16_t, uint16_t>;
-using Graph = dsm::Graph<uint16_t, uint16_t>;
-using SparseMatrix = dsm::SparseMatrix<uint16_t, bool>;
-using Street = dsm::Street<uint16_t, uint16_t>;
-using SpireStreet = dsm::SpireStreet<uint16_t, uint16_t>;
-using Agent = dsm::Agent<uint16_t, uint16_t, uint16_t>;
-using Itinerary = dsm::Itinerary<uint16_t>;
-using Node = dsm::Node<uint16_t, uint16_t>;
-using TrafficLight = dsm::TrafficLight<uint16_t, uint16_t, uint16_t>;
-using Roundabout = dsm::Roundabout<uint16_t, uint16_t>;
+using Dynamics = dsm::FirstOrderDynamics<uint16_t>;
+using Graph = dsm::Graph;
+using SparseMatrix = dsm::SparseMatrix<bool>;
+using Street = dsm::Street;
+using SpireStreet = dsm::SpireStreet;
+using Agent = dsm::Agent<uint16_t>;
+using Itinerary = dsm::Itinerary;
+using Node = dsm::Node;
+using TrafficLight = dsm::TrafficLight<uint16_t>;
+using Roundabout = dsm::Roundabout;
 
 TEST_CASE("Dynamics") {
   SUBCASE("Constructor") {
@@ -71,7 +71,7 @@ TEST_CASE("Dynamics") {
       graph.importMatrix("./data/matrix.dat");
       Dynamics dynamics{graph};
       WHEN("We add a span of destination nodes") {
-        std::array<uint16_t, 3> nodes{0, 1, 2};
+        std::array<uint32_t, 3> nodes{0, 1, 2};
         dynamics.setDestinationNodes(nodes);
         THEN("The destination nodes are added") {
           const auto& itineraries = dynamics.itineraries();
@@ -82,7 +82,7 @@ TEST_CASE("Dynamics") {
         }
       }
       WHEN("We add a span with non existing nodes") {
-        std::array<uint16_t, 3> nodes{0, 1, 169};
+        std::array<uint32_t, 3> nodes{0, 1, 169};
         THEN("An exception is thrown") {
           CHECK_THROWS_AS(dynamics.setDestinationNodes(nodes), std::invalid_argument);
         }
@@ -185,8 +185,8 @@ TEST_CASE("Dynamics") {
       Dynamics dynamics{graph};
       dynamics.setSeed(69);
       WHEN("We add one agent for existing itinerary") {
-        std::unordered_map<uint16_t, double> src{{0, 1.}};
-        std::unordered_map<uint16_t, double> dst{{2, 1.}};
+        std::unordered_map<uint32_t, double> src{{0, 1.}};
+        std::unordered_map<uint32_t, double> dst{{2, 1.}};
         dynamics.addItinerary(Itinerary{0, 2});
         dynamics.addAgentsRandomly(1, src, dst);
         THEN("The agents are correctly set") {
@@ -199,8 +199,8 @@ TEST_CASE("Dynamics") {
         }
       }
       WHEN("We add agents for existing itineraries") {
-        std::unordered_map<uint16_t, double> src{{1, 0.3}, {27, 0.3}, {118, 0.4}};
-        std::unordered_map<uint16_t, double> dst{{14, 0.3}, {102, 0.3}, {107, 0.4}};
+        std::unordered_map<uint32_t, double> src{{1, 0.3}, {27, 0.3}, {118, 0.4}};
+        std::unordered_map<uint32_t, double> dst{{14, 0.3}, {102, 0.3}, {107, 0.4}};
         dynamics.addItinerary(Itinerary{0, 14});
         dynamics.addItinerary(Itinerary{1, 102});
         dynamics.addItinerary(Itinerary{2, 107});
@@ -226,14 +226,14 @@ TEST_CASE("Dynamics") {
       }
       WHEN("We add agents without adding itineraries") {
         THEN("An exception is thrown") {
-          std::unordered_map<uint16_t, double> src{{0, 1.}};
-          std::unordered_map<uint16_t, double> dst{{10, 1.}};
+          std::unordered_map<uint32_t, double> src{{0, 1.}};
+          std::unordered_map<uint32_t, double> dst{{10, 1.}};
           CHECK_THROWS_AS(dynamics.addAgentsRandomly(1, src, dst), std::invalid_argument);
         }
       }
       WHEN("We try to add agents with non-normalized node maps") {
-        std::unordered_map<uint16_t, double> not_norm_weights{{0, 1.5}, {1, 0.5}};
-        std::unordered_map<uint16_t, double> norm_weights{{0, 0.5}, {1, 0.5}};
+        std::unordered_map<uint32_t, double> not_norm_weights{{0, 1.5}, {1, 0.5}};
+        std::unordered_map<uint32_t, double> norm_weights{{0, 0.5}, {1, 0.5}};
         THEN("An exception is thrown") {
           CHECK_THROWS_AS(dynamics.addAgentsRandomly(1, not_norm_weights, norm_weights),
                           std::invalid_argument);

--- a/test/Test_graph.cpp
+++ b/test/Test_graph.cpp
@@ -9,9 +9,9 @@
 
 #include "doctest.h"
 
-using Graph = dsm::Graph<uint, uint>;
-using SparseMatrix = dsm::SparseMatrix<uint, bool>;
-using Street = dsm::Street<uint, uint>;
+using Graph = dsm::Graph;
+using SparseMatrix = dsm::SparseMatrix<bool>;
+using Street = dsm::Street;
 using Path = std::vector<uint>;
 
 template <typename T1, typename T2>

--- a/test/Test_is_node.cpp
+++ b/test/Test_is_node.cpp
@@ -9,29 +9,21 @@ using dsm::is_node_v;
 using dsm::Node;
 
 // check the type trait
-static_assert(is_node<Node<uint8_t, uint8_t>>::value);
-static_assert(is_node<Node<uint16_t, uint16_t>>::value);
-static_assert(is_node<Node<uint32_t, uint32_t>>::value);
+static_assert(is_node<Node>::value);
 static_assert(!is_node<int>::value);
 static_assert(!is_node<unsigned int>::value);
 static_assert(!is_node<std::string>::value);
-static_assert(is_node<std::unique_ptr<Node<uint8_t, uint8_t>>>::value);
-static_assert(is_node<std::unique_ptr<Node<uint16_t, uint16_t>>>::value);
-static_assert(is_node<std::unique_ptr<Node<uint32_t, uint32_t>>>::value);
+static_assert(is_node<std::unique_ptr<Node>>::value);
 static_assert(!is_node<std::unique_ptr<int>>::value);
 static_assert(!is_node<std::unique_ptr<unsigned int>>::value);
 static_assert(!is_node<std::unique_ptr<std::string>>::value);
 
 // check the template variable
-static_assert(is_node_v<Node<uint8_t, uint8_t>>);
-static_assert(is_node_v<Node<uint16_t, uint16_t>>);
-static_assert(is_node_v<Node<uint32_t, uint32_t>>);
+static_assert(is_node_v<Node>);
 static_assert(!is_node_v<int>);
 static_assert(!is_node_v<unsigned int>);
 static_assert(!is_node_v<std::string>);
-static_assert(is_node_v<std::unique_ptr<Node<uint8_t, uint8_t>>>);
-static_assert(is_node_v<std::unique_ptr<Node<uint16_t, uint16_t>>>);
-static_assert(is_node_v<std::unique_ptr<Node<uint32_t, uint32_t>>>);
+static_assert(is_node_v<std::unique_ptr<Node>>);
 static_assert(!is_node_v<std::unique_ptr<int>>);
 static_assert(!is_node_v<std::unique_ptr<unsigned int>>);
 static_assert(!is_node_v<std::unique_ptr<std::string>>);

--- a/test/Test_is_street.cpp
+++ b/test/Test_is_street.cpp
@@ -9,29 +9,21 @@ using dsm::is_street_v;
 using dsm::Street;
 
 // check the type trait
-static_assert(is_street<Street<uint8_t, uint8_t>>::value);
-static_assert(is_street<Street<uint16_t, uint16_t>>::value);
-static_assert(is_street<Street<uint32_t, uint32_t>>::value);
+static_assert(is_street<Street>::value);
 static_assert(!is_street<int>::value);
 static_assert(!is_street<unsigned int>::value);
 static_assert(!is_street<std::string>::value);
-static_assert(is_street<std::unique_ptr<Street<uint8_t, uint8_t>>>::value);
-static_assert(is_street<std::unique_ptr<Street<uint16_t, uint16_t>>>::value);
-static_assert(is_street<std::unique_ptr<Street<uint32_t, uint32_t>>>::value);
+static_assert(is_street<std::unique_ptr<Street>>::value);
 static_assert(!is_street<std::unique_ptr<int>>::value);
 static_assert(!is_street<std::unique_ptr<unsigned int>>::value);
 static_assert(!is_street<std::unique_ptr<std::string>>::value);
 
 // check the template variable
-static_assert(is_street_v<Street<uint8_t, uint8_t>>);
-static_assert(is_street_v<Street<uint16_t, uint16_t>>);
-static_assert(is_street_v<Street<uint32_t, uint32_t>>);
+static_assert(is_street_v<Street>);
 static_assert(!is_street_v<int>);
 static_assert(!is_street_v<unsigned int>);
 static_assert(!is_street_v<std::string>);
-static_assert(is_street_v<std::unique_ptr<Street<uint8_t, uint8_t>>>);
-static_assert(is_street_v<std::unique_ptr<Street<uint16_t, uint16_t>>>);
-static_assert(is_street_v<std::unique_ptr<Street<uint32_t, uint32_t>>>);
+static_assert(is_street_v<std::unique_ptr<Street>>);
 static_assert(!is_street_v<std::unique_ptr<int>>);
 static_assert(!is_street_v<std::unique_ptr<unsigned int>>);
 static_assert(!is_street_v<std::unique_ptr<std::string>>);

--- a/test/Test_itinerary.cpp
+++ b/test/Test_itinerary.cpp
@@ -4,7 +4,7 @@
 
 #include "doctest.h"
 
-using Itinerary = dsm::Itinerary<uint8_t>;
+using Itinerary = dsm::Itinerary;
 
 TEST_CASE("Itinerary") {
   SUBCASE("Constructors") {
@@ -22,7 +22,7 @@ TEST_CASE("Itinerary") {
     GIVEN("An itinerary id, its destination id and a transition matrix") {
       uint8_t itineraryId{0};
       uint8_t destinationId{2};
-      dsm::SparseMatrix<uint8_t, bool> path{1, 1};
+      dsm::SparseMatrix<bool> path{1, 1};
       WHEN("The Itinerary is constructed") {
         Itinerary itinerary{itineraryId, destinationId, path};
         THEN("The source, destination, and path are set correctly") {
@@ -38,7 +38,7 @@ TEST_CASE("Itinerary") {
     GIVEN("An itinerary id, its destination id and a transition matrix") {
       uint8_t itineraryId{0};
       uint8_t destinationId{2};
-      dsm::SparseMatrix<uint8_t, bool> path{1, 1};
+      dsm::SparseMatrix<bool> path{1, 1};
       Itinerary itinerary{itineraryId, destinationId, path};
       WHEN("The destination is set") {
         uint8_t newDestinationId{3};

--- a/test/Test_node.cpp
+++ b/test/Test_node.cpp
@@ -3,9 +3,10 @@
 #include "Node.hpp"
 
 #include "doctest.h"
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
-using Node = dsm::Node<uint16_t, uint16_t>;
-using TrafficLight = dsm::TrafficLight<uint16_t, uint16_t, uint16_t>;
+using Node = dsm::Node;
+using TrafficLight = dsm::TrafficLight<uint32_t>;
 
 TEST_CASE("Node") {
   SUBCASE("Constructor") {

--- a/test/Test_sparsematrix.cpp
+++ b/test/Test_sparsematrix.cpp
@@ -1,7 +1,6 @@
 
 #include "SparseMatrix.hpp"
 
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
 using namespace dsm;
@@ -15,7 +14,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the matrix is created
     THEN: the matrix should have 0 rows and 0 columns and a max size of 0
     */
-    SparseMatrix<uint32_t, bool> m;
+    SparseMatrix<bool> m;
     // Check the dimensions
     CHECK(m.getRowDim() == 0);
     CHECK(m.getColDim() == 0);
@@ -29,7 +28,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the matrix is created
     THEN: the matrix should have 3 rows and 4 columns and a max size of 12
     */
-    SparseMatrix<uint32_t, bool> m(3, 4);
+    SparseMatrix<bool> m(3, 4);
     // Check the dimensions
     CHECK(m.getRowDim() == 3);
     CHECK(m.getColDim() == 4);
@@ -42,7 +41,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the matrix is created
     THEN: the matrix should have 3 rows and 1 column and a max size of 3
     */
-    SparseMatrix<uint32_t, bool> m(3);
+    SparseMatrix<bool> m(3);
     // Check the dimensions
     CHECK(m.getRowDim() == 3);
     CHECK(m.getColDim() == 1);
@@ -57,7 +56,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the inserted element is out
     of range
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Check that an exception is thrown if the element is out of range
     CHECK_THROWS(m.insert_or_assign(3, 2, true));
   }
@@ -68,7 +67,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should insert a value in the matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Insert a true value
     m.insert(0, 0, true);
     m.insert(5, true);
@@ -89,7 +88,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should insert a value in the matrix
     */
-    SparseMatrix<uint32_t, int> m(4, 3);
+    SparseMatrix<int> m(4, 3);
     // Insert a true value
     m.insert_or_assign(1, 2, 10);
     CHECK(m(1, 2) == 10);
@@ -103,7 +102,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the element is out of range
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Check that an exception is thrown if the element is out of range
     CHECK_THROWS(m.erase(-1, -2));
     CHECK_THROWS(m.erase(3, 2));
@@ -115,7 +114,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should delete a value in the matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.erase(0, 0);
     // Check if the value has been deleted
@@ -130,7 +129,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should delete all the elements and dimensions in the
     matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.clear();
     // Check if the matrix is empty
@@ -145,7 +144,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the element is out of range
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     CHECK_THROWS(m.contains(-2, -1));
     CHECK_THROWS(m.contains(-1));
   }
@@ -156,7 +155,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called
     THEN: the function should return true
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(2, 1, true);
     CHECK(m.contains(0, 0));
@@ -169,7 +168,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the row is out of range
     */
-    SparseMatrix<uint32_t, bool> m(4, 3);
+    SparseMatrix<bool> m(4, 3);
     CHECK_THROWS(m.getRow(-1));
     CHECK_THROWS(m.getRow(4));
   }
@@ -182,7 +181,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return a vector (SparseMatrix) containing the
     elements of the row
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Create a row
     m.insert(0, 0, true);
     m.insert(0, 2, true);
@@ -202,7 +201,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return a vector (SparseMatrix) containing the
     elements of the row
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Create a row
     m.insert(0, 0, true);
     m.insert(0, 2, true);
@@ -221,7 +220,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the column is out of range
     */
-    SparseMatrix<uint32_t, bool> m(3, 6);
+    SparseMatrix<bool> m(3, 6);
     CHECK_THROWS(m.getCol(6));
   }
   SUBCASE("getCol") {
@@ -233,7 +232,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return a vector (SparseMatrix) containingthe
     elements of the column
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Create a column
     m.insert(0, 0, true);
     m.insert(2, 0, true);
@@ -253,7 +252,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return a vector (SparseMatrix) containingthe
     elements of the column
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Create a column
     m.insert(0, 0, true);
     m.insert(2, 0, true);
@@ -271,7 +270,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the number of rows in the matrix
     */
-    SparseMatrix<uint32_t, bool> m(7, 3);
+    SparseMatrix<bool> m(7, 3);
     CHECK(m.getRowDim() == 7);
   }
   SUBCASE("Get column dimension") {
@@ -281,7 +280,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the number of columns in the matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 10);
+    SparseMatrix<bool> m(3, 10);
     CHECK(m.getColDim() == 10);
   }
   SUBCASE("Get max_size") {
@@ -293,7 +292,7 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should return the maximum number of elements that can be
     stored in the matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 5);
+    SparseMatrix<bool> m(3, 5);
     CHECK(m.max_size() == 15);
   }
   SUBCASE("Get size") {
@@ -304,7 +303,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the number of elements in the matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(0, 2, true);
@@ -319,7 +318,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the row is out of range
     */
-    SparseMatrix<uint32_t, bool> m(5, 3);
+    SparseMatrix<bool> m(5, 3);
     CHECK_THROWS(m.eraseRow(5));
   }
   SUBCASE("Erase row") {
@@ -330,7 +329,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should delete all the elements in the row
     */
-    SparseMatrix<uint32_t, bool> d(3, 3);
+    SparseMatrix<bool> d(3, 3);
     // Create a row
     d.insert(0, 0, true);
     d.insert(1, 2, true);
@@ -362,7 +361,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the column is out of range
     */
-    SparseMatrix<uint32_t, bool> m(3, 5);
+    SparseMatrix<bool> m(3, 5);
     CHECK_THROWS(m.eraseColumn(5));
   }
   SUBCASE("Erase column") {
@@ -373,7 +372,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should delete all the elements in the column
     */
-    SparseMatrix<uint32_t, bool> d(3, 3);
+    SparseMatrix<bool> d(3, 3);
     d.insert(0, 0, true);
     d.insert(1, 2, true);
     d.insert(2, 1, true);
@@ -400,8 +399,8 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should throw an exception if the matrix is empty
     */
-    SparseMatrix<uint32_t, bool> m(1, 5);
-    SparseMatrix<uint32_t, bool> m2(3, 6);
+    SparseMatrix<bool> m(1, 5);
+    SparseMatrix<bool> m2(3, 6);
     CHECK_THROWS(m.getDegreeVector());
     CHECK_THROWS(m2.getDegreeVector());
   }
@@ -413,7 +412,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return a vector containing the degree of each row
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -434,7 +433,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return a matrix containing the normalized rows
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     // Create a row
     m.insert(0, 0, true);
     m.insert(0, 1, true);
@@ -460,7 +459,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return a matrix containing the normalized columns
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(0, 2, true);
@@ -484,7 +483,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should symmetrize the matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -506,8 +505,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
-    SparseMatrix<uint32_t, bool> m2(3, 4);
+    SparseMatrix<bool> m(3, 3);
+    SparseMatrix<bool> m2(3, 4);
     CHECK_THROWS(m + m2);
   }
   SUBCASE("+ operator") {
@@ -517,11 +516,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should sum the two matrices
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
-    SparseMatrix<uint32_t, bool> m2(3, 3);
+    SparseMatrix<bool> m2(3, 3);
     m2.insert(0, 0, true);
     m2.insert(1, 0, true);
     m2.insert(2, 1, true);
@@ -542,8 +541,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
-    SparseMatrix<uint32_t, bool> m2(3, 4);
+    SparseMatrix<bool> m(3, 3);
+    SparseMatrix<bool> m2(3, 4);
     CHECK_THROWS(m += m2);
   }
   SUBCASE("+= operator") {
@@ -553,11 +552,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should sum the two matrices
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
-    SparseMatrix<uint32_t, bool> m2(3, 3);
+    SparseMatrix<bool> m2(3, 3);
     m2.insert(0, 0, true);
     m2.insert(1, 0, true);
     m2.insert(2, 1, true);
@@ -578,8 +577,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
-    SparseMatrix<uint32_t, bool> m2(3, 4);
+    SparseMatrix<bool> m(3, 3);
+    SparseMatrix<bool> m2(3, 4);
     CHECK_THROWS(m - m2);
   }
   SUBCASE("- operator") {
@@ -589,11 +588,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should subtract the two matrices
     */
-    SparseMatrix<uint32_t, int> m(3, 3);
+    SparseMatrix<int> m(3, 3);
     m.insert(0, 0, 1);
     m.insert(0, 1, 2);
     m.insert(1, 2, 3);
-    SparseMatrix<uint32_t, int> m2(3, 3);
+    SparseMatrix<int> m2(3, 3);
     m2.insert(0, 0, 1);
     m2.insert(1, 0, 2);
     m2.insert(2, 1, 3);
@@ -614,8 +613,8 @@ TEST_CASE("Boolean Matrix") {
     THEN: the function should throw an exception if the matrices have different
     dimensions
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
-    SparseMatrix<uint32_t, bool> m2(3, 4);
+    SparseMatrix<bool> m(3, 3);
+    SparseMatrix<bool> m2(3, 4);
     CHECK_THROWS(m -= m2);
   }
   SUBCASE("-= operator") {
@@ -625,11 +624,11 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on two matrices
     THEN: the function should subtract the two matrices
     */
-    SparseMatrix<uint32_t, int> m(3, 3);
+    SparseMatrix<int> m(3, 3);
     m.insert(0, 0, 1);
     m.insert(0, 1, 2);
     m.insert(1, 2, 3);
-    SparseMatrix<uint32_t, int> m2(3, 3);
+    SparseMatrix<int> m2(3, 3);
     m2.insert(0, 0, 1);
     m2.insert(1, 0, 2);
     m2.insert(2, 1, 3);
@@ -649,8 +648,8 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a non-square matrix
     THEN: the function should throw an exception
     */
-    SparseMatrix<uint32_t, double> m(4, 3);
-    SparseMatrix<uint32_t, double> m2(3, 4);
+    SparseMatrix<double> m(4, 3);
+    SparseMatrix<double> m2(3, 4);
     CHECK_THROWS(m.getStrengthVector());
     CHECK_THROWS(m2.getStrengthVector());
   }
@@ -662,7 +661,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a street with 1 vehicle and length 10
     THEN: the function should return a vector with 0.1
     */
-    SparseMatrix<uint32_t, double> m(3, 3);
+    SparseMatrix<double> m(3, 3);
     m.insert(0, 0, 0.3);
     m.insert(0, 1, 0.3);
     m.insert(0, 2, 0.1);
@@ -682,7 +681,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a non-square matrix
     THEN: the function should throw an exception
     */
-    SparseMatrix<uint32_t, double> m(4, 3);
+    SparseMatrix<double> m(4, 3);
     CHECK_THROWS(m.getLaplacian());
   }
   SUBCASE("getLaplacian") {
@@ -692,7 +691,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should return the Laplacian matrix of the matrix
     */
-    SparseMatrix<uint32_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -711,7 +710,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should reshape the matrix
     */
-    SparseMatrix<uint16_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -728,7 +727,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should reshape the matrix
     */
-    SparseMatrix<uint16_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -745,7 +744,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should reshape the matrix
     */
-    SparseMatrix<uint16_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(0, 1, true);
     m.insert(1, 2, true);
@@ -762,7 +761,7 @@ TEST_CASE("Boolean Matrix") {
     WHEN: the function is called on a matrix
     THEN: the function should insert a value in the matrix and expanding it
     */
-    SparseMatrix<uint16_t, bool> m(3, 3);
+    SparseMatrix<bool> m(3, 3);
     m.insert(0, 0, true);
     m.insert(1, 2, true);
     m.insert_and_expand(3, 4, true);

--- a/test/Test_street.cpp
+++ b/test/Test_street.cpp
@@ -5,6 +5,7 @@
 #include "Agent.hpp"
 #include "Node.hpp"
 #include "Street.hpp"
+#include "../utility/Typedef.hpp"
 
 #include "doctest.h"
 
@@ -24,7 +25,7 @@ TEST_CASE("Street") {
     Street street{1, std::make_pair(0, 1)};
     CHECK_EQ(street.id(), 1);
     CHECK_EQ(street.capacity(), 1);
-    CHECK_EQ(street.transportCapacity(), 65535);
+    CHECK_EQ(street.transportCapacity(), std::numeric_limits<dsm::Size>::max());
     CHECK_EQ(street.length(), 1.);
     CHECK_EQ(street.nodePair().first, 0);
     CHECK_EQ(street.nodePair().second, 1);
@@ -41,7 +42,7 @@ TEST_CASE("Street") {
     Street street{1, 2, 3.5, std::make_pair(4, 5)};
     CHECK_EQ(street.id(), 1);
     CHECK_EQ(street.capacity(), 2);
-    CHECK_EQ(street.transportCapacity(), 65535);
+    CHECK_EQ(street.transportCapacity(), std::numeric_limits<dsm::Size>::max());
     CHECK_EQ(street.length(), 3.5);
     CHECK_EQ(street.nodePair().first, 4);
     CHECK_EQ(street.nodePair().second, 5);
@@ -58,7 +59,7 @@ TEST_CASE("Street") {
     Street street{1, 2, 3.5, 40., std::make_pair(4, 5)};
     CHECK_EQ(street.id(), 1);
     CHECK_EQ(street.capacity(), 2);
-    CHECK_EQ(street.transportCapacity(), 65535);
+    CHECK_EQ(street.transportCapacity(), std::numeric_limits<dsm::Size>::max());
     CHECK_EQ(street.length(), 3.5);
     CHECK_EQ(street.nodePair().first, 4);
     CHECK_EQ(street.nodePair().second, 5);

--- a/test/Test_street.cpp
+++ b/test/Test_street.cpp
@@ -8,10 +8,10 @@
 
 #include "doctest.h"
 
-using Agent = dsm::Agent<uint16_t, uint16_t, double>;
-using Node = dsm::Node<uint16_t, uint16_t>;
-using Street = dsm::Street<uint16_t, uint16_t>;
-using SpireStreet = dsm::SpireStreet<uint16_t, uint16_t>;
+using Agent = dsm::Agent<double>;
+using Node = dsm::Node;
+using Street = dsm::Street;
+using SpireStreet = dsm::SpireStreet;
 
 TEST_CASE("Street") {
   SUBCASE("Constructor_1") {


### PR DESCRIPTION
This PR removes the `Id` and `Size` template parameters used throughout the code. The syntax is maintained and the types are defined in the new Typedef file.
The classes which aren't templates anymore have the method definitions moved into .cpp files.