### PR TITLE
Manage multi-lane Traffic Lights

### DIFF
--- a/src/dsm/dsm.hpp
+++ b/src/dsm/dsm.hpp
@@ -6,7 +6,7 @@
 
 static constexpr uint8_t DSM_VERSION_MAJOR = 2;
 static constexpr uint8_t DSM_VERSION_MINOR = 1;
-static constexpr uint8_t DSM_VERSION_PATCH = 0;
+static constexpr uint8_t DSM_VERSION_PATCH = 1;
 
 #define DSM_VERSION \
   std::format("{}.{}.{}", DSM_VERSION_MAJOR, DSM_VERSION_MINOR, DSM_VERSION_PATCH)

--- a/src/dsm/headers/Node.cpp
+++ b/src/dsm/headers/Node.cpp
@@ -48,6 +48,13 @@ namespace dsm {
     ++m_agentCounter;
   }
 
+  void Intersection::setLeftTurnRatio(std::pair<double, double> ratio) {
+    assert((void("Left turn ratio components must be between 0 and 1."),
+            ratio.first >= 0. && ratio.first <= 1. && ratio.second >= 0. &&
+                ratio.second <= 1.));
+    m_leftTurnRatio = std::move(ratio);
+  }
+
   void Intersection::removeAgent(Id agentId) {
     assert((void("Trying to remove an agent not on the node"),
             std::erase_if(m_agents, [agentId](const auto& p) {

--- a/src/dsm/headers/Node.cpp
+++ b/src/dsm/headers/Node.cpp
@@ -48,13 +48,6 @@ namespace dsm {
     ++m_agentCounter;
   }
 
-  void Intersection::setLeftTurnRatio(std::pair<double, double> ratio) {
-    assert((void("Left turn ratio components must be between 0 and 1."),
-            ratio.first >= 0. && ratio.first <= 1. && ratio.second >= 0. &&
-                ratio.second <= 1.));
-    m_leftTurnRatio = std::move(ratio);
-  }
-
   void Intersection::removeAgent(Id agentId) {
     assert((void("Trying to remove an agent not on the node"),
             std::erase_if(m_agents, [agentId](const auto& p) {

--- a/src/dsm/headers/Node.hpp
+++ b/src/dsm/headers/Node.hpp
@@ -360,10 +360,11 @@ namespace dsm {
       }
     } else {
       if (hasPriority) {
-        return m_counter < pair.first * m_leftTurnRatio.value().first;
+        return m_counter < pair.first * (1. - m_leftTurnRatio.value().first);
       } else {
         return m_counter > pair.first &&
-               m_counter < pair.first + pair.second * m_leftTurnRatio.value().second;
+               m_counter <
+                   pair.first + pair.second * (1. - m_leftTurnRatio.value().second);
       }
     }
   }

--- a/src/dsm/headers/Street.cpp
+++ b/src/dsm/headers/Street.cpp
@@ -161,6 +161,16 @@ namespace dsm {
     return nAgents;
   }
 
+  double Street::deltaAngle(double const previousStreetAngle) const {
+    double deltaAngle{m_angle - previousStreetAngle};
+    if (deltaAngle > std::numbers::pi) {
+      deltaAngle -= 2 * std::numbers::pi;
+    } else if (deltaAngle < -std::numbers::pi) {
+      deltaAngle += 2 * std::numbers::pi;
+    }
+    return deltaAngle;
+  }
+
   SpireStreet::SpireStreet(Id id, const Street& street)
       : Street(id, street), m_agentCounterIn{0}, m_agentCounterOut{0} {}
 

--- a/src/dsm/headers/Street.hpp
+++ b/src/dsm/headers/Street.hpp
@@ -195,6 +195,10 @@ namespace dsm {
     /// @brief Get the number of agents on all queues
     /// @return Size The number of agents on all queues
     Size nExitingAgents() const;
+    /// @brief Get the delta angle between the street and the previous street, normalized between -pi and pi
+    /// @param previousStreetAngle The angle of the previous street
+    /// @return double The delta angle between the street and the previous street
+    double deltaAngle(double const previousStreetAngle) const;
 
     virtual void addAgent(Id agentId);
     /// @brief Add an agent to the street's queue

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -633,6 +633,73 @@ TEST_CASE("Dynamics") {
         }
       }
     }
+    GIVEN(
+        "A traffic light managing an intersection with 4 3-lanes streets and 4 1-lane "
+        "streets") {
+      // Streets
+      Street s0_1{1, 1, 30., 15., std::make_pair(0, 1), 3};
+      Street s1_0{5, 1, 30., 15., std::make_pair(1, 0), 3};
+      Street s1_2{7, 1, 30., 15., std::make_pair(1, 2), 3};
+      Street s2_1{11, 1, 30., 15., std::make_pair(2, 1), 3};
+
+      Street s3_1{8, 1, 30., 15., std::make_pair(3, 1)};
+      Street s1_3{16, 1, 30., 15., std::make_pair(1, 3)};
+      Street s4_1{21, 1, 30., 15., std::make_pair(4, 1)};
+      Street s1_4{9, 1, 30., 15., std::make_pair(1, 4)};
+
+      Graph graph2;
+      graph2.addNode(std::make_unique<TrafficLight>(1));
+      graph2.addStreets(s0_1, s1_0, s1_2, s2_1, s3_1, s1_3, s4_1, s1_4);
+      graph2.buildAdj();
+      graph2.adjustNodeCapacities();
+      graph2.normalizeStreetCapacities();
+      auto const& nodes = graph2.nodeSet();
+      auto& tl = dynamic_cast<TrafficLight&>(*nodes.at(1));
+      tl.setDelay(3);
+      tl.setLeftTurnRatio(0.3);
+      // NO! Now testing red light
+      // tl.setPhase(2);
+      tl.addStreetPriority(21);
+      tl.addStreetPriority(8);
+      tl.setCoords({0., 0.});
+      nodes.at(0)->setCoords({-1., 0.});
+      nodes.at(2)->setCoords({1., 0.});
+      nodes.at(3)->setCoords({0., -1.});
+      nodes.at(4)->setCoords({0., 1.});
+      graph2.buildStreetAngles();
+
+      Dynamics dynamics{graph2};
+      dynamics.setSeed(69);
+
+      std::vector<uint32_t> destinationNodes{0, 2, 3, 4};
+      dynamics.setDestinationNodes(destinationNodes);
+
+      CHECK(tl.leftTurnRatio().has_value());
+
+      WHEN("We add agents and make the system evolve") {
+        Agent agent1{0, 2, 0};
+        Agent agent2{1, 4, 0};
+        dynamics.addAgents(agent1, agent2);
+        dynamics.evolve(false);
+        dynamics.evolve(false);
+        THEN("The agents are correctly placed") {
+          CHECK_EQ(dynamics.agents().at(0)->streetId().value(), 1);
+          CHECK_EQ(dynamics.agents().at(1)->streetId().value(), 1);
+        }
+        dynamics.evolve(false);
+        dynamics.evolve(false);
+        dynamics.evolve(false);
+        THEN("The agent 0 passes and agent 1 waits") {
+          CHECK_EQ(dynamics.agents().at(0)->streetId().value(), 7);
+          CHECK_EQ(dynamics.agents().at(1)->streetId().value(), 1);
+        }
+        dynamics.evolve(false);
+        THEN("The agent 1 passes") {
+          CHECK_EQ(dynamics.agents().at(0)->streetId().value(), 7);
+          CHECK_EQ(dynamics.agents().at(1)->streetId().value(), 9);
+        }
+      }
+    }
   }
   SUBCASE("Traffic Lights optimization algorithm") {
     GIVEN("A dynamics object with a traffic light intersection") {

--- a/test/Test_dynamics.cpp
+++ b/test/Test_dynamics.cpp
@@ -568,6 +568,71 @@ TEST_CASE("Dynamics") {
         }
       }
     }
+    GIVEN(
+        "A traffic light managing an intersection with 4 3-lanes streets and 4 1-lane "
+        "streets") {
+      // Streets
+      Street s0_1{1, 1, 30., 15., std::make_pair(0, 1), 3};
+      Street s1_0{5, 1, 30., 15., std::make_pair(1, 0), 3};
+      Street s1_2{7, 1, 30., 15., std::make_pair(1, 2), 3};
+      Street s2_1{11, 1, 30., 15., std::make_pair(2, 1), 3};
+
+      Street s3_1{8, 1, 30., 15., std::make_pair(3, 1)};
+      Street s1_3{16, 1, 30., 15., std::make_pair(1, 3)};
+      Street s4_1{21, 1, 30., 15., std::make_pair(4, 1)};
+      Street s1_4{9, 1, 30., 15., std::make_pair(1, 4)};
+
+      Graph graph2;
+      graph2.addNode(std::make_unique<TrafficLight>(1));
+      graph2.addStreets(s0_1, s1_0, s1_2, s2_1, s3_1, s1_3, s4_1, s1_4);
+      graph2.buildAdj();
+      graph2.adjustNodeCapacities();
+      graph2.normalizeStreetCapacities();
+      auto const& nodes = graph2.nodeSet();
+      auto& tl = dynamic_cast<TrafficLight&>(*nodes.at(1));
+      tl.setDelay(3);
+      tl.setLeftTurnRatio(0.3);
+      tl.setPhase(2);
+      tl.addStreetPriority(1);
+      tl.setCoords({0., 0.});
+      nodes.at(0)->setCoords({-1., 0.});
+      nodes.at(2)->setCoords({1., 0.});
+      nodes.at(3)->setCoords({0., -1.});
+      nodes.at(4)->setCoords({0., 1.});
+      graph2.buildStreetAngles();
+
+      Dynamics dynamics{graph2};
+      dynamics.setSeed(69);
+
+      std::vector<uint32_t> destinationNodes{0, 2, 3, 4};
+      dynamics.setDestinationNodes(destinationNodes);
+
+      CHECK(tl.leftTurnRatio().has_value());
+
+      WHEN("We add agents and make the system evolve") {
+        Agent agent1{0, 2, 0};
+        Agent agent2{1, 4, 0};
+        dynamics.addAgents(agent1, agent2);
+        dynamics.evolve(false);
+        dynamics.evolve(false);
+        THEN("The agents are correctly placed") {
+          CHECK_EQ(dynamics.agents().at(0)->streetId().value(), 1);
+          CHECK_EQ(dynamics.agents().at(1)->streetId().value(), 1);
+        }
+        dynamics.evolve(false);
+        dynamics.evolve(false);
+        dynamics.evolve(false);
+        THEN("The agent 0 passes and agent 1 waits") {
+          CHECK_EQ(dynamics.agents().at(0)->streetId().value(), 7);
+          CHECK_EQ(dynamics.agents().at(1)->streetId().value(), 1);
+        }
+        dynamics.evolve(false);
+        THEN("The agent 1 passes") {
+          CHECK_EQ(dynamics.agents().at(0)->streetId().value(), 7);
+          CHECK_EQ(dynamics.agents().at(1)->streetId().value(), 9);
+        }
+      }
+    }
   }
   SUBCASE("Traffic Lights optimization algorithm") {
     GIVEN("A dynamics object with a traffic light intersection") {


### PR DESCRIPTION
The base idea is adding a new `std::pair<double, double>`  to Traffic Light class.
In this way, we can have four different time intervals:
- `0` -> `delay.first * (1 - pair.first)` in which is green for right/straight turns;
- `delay.first * (1 - pair.first)` -> `delay.first` in which is green for left turns;
- `delay.first` -> `delay.first + delay.second * (1 - pair.second)` in which is red for right/straight turns;
- `delay.first + delay.second * (1 - pair.second)` -> `delay.second` in which is red for left turns;